### PR TITLE
Adding comment for TX_ENABLE/TX_DIS relationship.  Fixed comma omisions.

### DIFF
--- a/inc/tainetworkif.h
+++ b/inc/tainetworkif.h
@@ -163,6 +163,8 @@ typedef enum _tai_network_interface_attr_t
     /**
      * @brief TX Enable
      *
+     * Interpreted as complement of MSA defined TX_DIS signal
+     *
      * @type bool
      */
     TAI_NETWORK_INTERFACE_ATTR_TX_ENABLE,
@@ -303,49 +305,49 @@ typedef enum _tai_network_interface_attr_t
      *
      * @type bool
      */
-    TAI_NETWORK_INTERFACE_ATTR_PULSE_SHAPING_TX
+    TAI_NETWORK_INTERFACE_ATTR_PULSE_SHAPING_TX,
 
     /**
      * @brief Pulse shaping enabled on RX
      *
      * @type bool
      */
-    TAI_NETWORK_INTERFACE_ATTR_PULSE_SHAPING_RX
+    TAI_NETWORK_INTERFACE_ATTR_PULSE_SHAPING_RX,
 
     /**
      * @brief Pulse shaping beta on TX
      *
      * @type #tai_float_t
      */
-    TAI_NETWORK_INTERFACE_ATTR_PULSE_SHAPING_TX_BETA
+    TAI_NETWORK_INTERFACE_ATTR_PULSE_SHAPING_TX_BETA,
 
     /**
      * @brief Pulse shaping beta on RX
      *
      * @type #tai_float_t
      */
-    TAI_NETWORK_INTERFACE_ATTR_PULSE_SHAPING_RX_BETA
+    TAI_NETWORK_INTERFACE_ATTR_PULSE_SHAPING_RX_BETA,
 
     /**
      * @brief RX VOA attenuation in dB
      *
      * @type #tai_float_t
      */
-    TAI_NETWORK_INTERFACE_ATTR_VOA_RX
+    TAI_NETWORK_INTERFACE_ATTR_VOA_RX,
 
     /**
      * @brief Channel by frequency in THz
      *
      * @type #tai_float_t
      */
-    TAI_NETWORK_INTERFACE_ATTR_CHANNEL_FREQ
+    TAI_NETWORK_INTERFACE_ATTR_CHANNEL_FREQ,
 
     /**
      * @brief Channel by lambda by nm
      *
      * @type #tai_float_t
      */
-    TAI_NETWORK_INTERFACE_ATTR_CHANNEL_LAMBDA
+    TAI_NETWORK_INTERFACE_ATTR_CHANNEL_LAMBDA,
 
     /**
      * @brief End of attributes


### PR DESCRIPTION
Added comment to provide relationship between ```TAI_NETWORK_INTERFACE_ATTR_TX_ENABLE``` and ```TX_DIS```.  Fixed comma omissions for previously added attributes.