### PR TITLE
meta: support handling default values

### DIFF
--- a/inc/taihostif.h
+++ b/inc/taihostif.h
@@ -113,6 +113,8 @@ typedef enum _tai_host_interface_attr_t
      * @brief FEC type
      *
      * @type #tai_host_interface_fec_type_t
+     * @flags CREATE_AND_SET
+     * @default TAI_HOST_INTERFACE_FEC_TYPE_NONE
      */
     TAI_HOST_INTERFACE_ATTR_FEC_TYPE,
 
@@ -120,6 +122,8 @@ typedef enum _tai_host_interface_attr_t
      * @brief Loopback type
      *
      * @type #tai_host_interface_loopback_type_t
+     * @flags CREATE_AND_SET
+     * @default TAI_HOST_INTERFACE_LOOPBACK_TYPE_NONE
      */
     TAI_HOST_INTERFACE_ATTR_LOOPBACK_TYPE,
 

--- a/inc/taimodule.h
+++ b/inc/taimodule.h
@@ -197,6 +197,8 @@ typedef enum _tai_module_attr_t
      * @brief The admin state of the module
      *
      * @type #tai_module_admin_status_t
+     * @flags CREATE_AND_SET
+     * @default TAI_MODULE_ADMIN_STATUS_UP
      */
     TAI_MODULE_ATTR_ADMIN_STATUS,
 
@@ -208,6 +210,8 @@ typedef enum _tai_module_attr_t
      * by setting some netif attributes (e.g TAI_NETWORK_INTERFACE_ATTR_MODULATION_FORMAT )
      *
      * @type #tai_object_map_list_t
+     * @flags CREATE_AND_SET
+     * @defaults empty-list
      */
     TAI_MODULE_ATTR_TRIBUTARY_MAPPING,
 
@@ -216,6 +220,7 @@ typedef enum _tai_module_attr_t
      *
      * @type tai_pointer_t tai_module_shutdown_request_notification_fn
      * @flags CREATE_AND_SET
+     * @default NULL
      */
     TAI_MODULE_ATTR_MODULE_SHUTDOWN_REQUEST_NOTIFY,
 
@@ -224,6 +229,7 @@ typedef enum _tai_module_attr_t
      *
      * @type tai_pointer_t tai_module_state_change_notification_fn
      * @flags CREATE_AND_SET
+     * @default NULL
      */
     TAI_MODULE_ATTR_MODULE_STATE_CHANGE_NOTIFY,
 

--- a/inc/tainetworkif.h
+++ b/inc/tainetworkif.h
@@ -176,6 +176,8 @@ typedef enum _tai_network_interface_attr_t
      * Interpreted as complement of MSA defined TX_DIS signal
      *
      * @type bool
+     * @flags CREATE_AND_SET
+     * @default true
      */
     TAI_NETWORK_INTERFACE_ATTR_TX_ENABLE,
 
@@ -191,6 +193,8 @@ typedef enum _tai_network_interface_attr_t
      * @brief The TX output power in dBm
      *
      * @type #tai_float_t
+     * @flags CREATE_AND_SET
+     * @default vendor-specific
      */
     TAI_NETWORK_INTERFACE_ATTR_OUTPUT_POWER,
 
@@ -206,6 +210,8 @@ typedef enum _tai_network_interface_attr_t
      * @brief The TX laser frequency in Hz
      *
      * @type #tai_uint64_t
+     * @flags CREATE_AND_SET
+     * @default vendor-specific
      */
     TAI_NETWORK_INTERFACE_ATTR_TX_LASER_FREQ,
 
@@ -213,6 +219,8 @@ typedef enum _tai_network_interface_attr_t
      * @brief The TX laser fine tune frequency in Hz
      *
      * @type #tai_int64_t
+     * @flags CREATE_AND_SET
+     * @default vendor-specific
      */
     TAI_NETWORK_INTERFACE_ATTR_TX_FINE_TUNE_LASER_FREQ,
 
@@ -220,6 +228,8 @@ typedef enum _tai_network_interface_attr_t
      * @brief The modulation format
      *
      * @type #tai_network_interface_modulation_format_t
+     * @flags CREATE_AND_SET
+     * @default vendor-specific
      */
     TAI_NETWORK_INTERFACE_ATTR_MODULATION_FORMAT,
 
@@ -244,6 +254,8 @@ typedef enum _tai_network_interface_attr_t
      * @brief Differential phase encoding
      *
      * @type bool
+     * @flags CREATE_AND_SET
+     * @default vendor-specific
      */
     TAI_NETWORK_INTERFACE_ATTR_DIFFERENTIAL_ENCODING,
 
@@ -251,6 +263,7 @@ typedef enum _tai_network_interface_attr_t
      * @brief The operational state of the network interface
      *
      * @type #tai_network_interface_oper_status_t
+     * @flags READ_ONLY
      */
     TAI_NETWORK_INTERFACE_ATTR_OPER_STATUS,
 
@@ -307,6 +320,8 @@ typedef enum _tai_network_interface_attr_t
      * @brief Pulse shaping enabled on TX
      *
      * @type bool
+     * @flags CREATE_AND_SET
+     * @default vendor-specific
      */
     TAI_NETWORK_INTERFACE_ATTR_PULSE_SHAPING_TX,
 
@@ -314,6 +329,8 @@ typedef enum _tai_network_interface_attr_t
      * @brief Pulse shaping enabled on RX
      *
      * @type bool
+     * @flags CREATE_AND_SET
+     * @default vendor-specific
      */
     TAI_NETWORK_INTERFACE_ATTR_PULSE_SHAPING_RX,
 
@@ -321,6 +338,8 @@ typedef enum _tai_network_interface_attr_t
      * @brief Pulse shaping beta on TX
      *
      * @type #tai_float_t
+     * @flags CREATE_AND_SET
+     * @default vendor-specific
      */
     TAI_NETWORK_INTERFACE_ATTR_PULSE_SHAPING_TX_BETA,
 
@@ -328,6 +347,8 @@ typedef enum _tai_network_interface_attr_t
      * @brief Pulse shaping beta on RX
      *
      * @type #tai_float_t
+     * @flags CREATE_AND_SET
+     * @default vendor-specific
      */
     TAI_NETWORK_INTERFACE_ATTR_PULSE_SHAPING_RX_BETA,
 
@@ -335,6 +356,8 @@ typedef enum _tai_network_interface_attr_t
      * @brief RX VOA attenuation in dB
      *
      * @type #tai_float_t
+     * @flags CREATE_AND_SET
+     * @default vendor-specific
      */
     TAI_NETWORK_INTERFACE_ATTR_VOA_RX,
 
@@ -342,6 +365,8 @@ typedef enum _tai_network_interface_attr_t
      * @brief Loopback type
      *
      * @type #tai_network_interface_loopback_type_t
+     * @flags CREATE_AND_SET
+     * @default TAI_NETWORK_INTERFACE_LOOPBACK_TYPE_NONE
      */
     TAI_NETWORK_INTERFACE_ATTR_LOOPBACK_TYPE,
 
@@ -349,6 +374,8 @@ typedef enum _tai_network_interface_attr_t
      * @brief PRBS type
      *
      * @type #tai_network_interface_prbs_type_t
+     * @flags CREATE_AND_SET
+     * @default TAI_NETWORK_INTERFACE_PRBS_TYPE_NONE
      */
     TAI_NETWORK_INTERFACE_ATTR_PRBS_TYPE,
 
@@ -366,6 +393,8 @@ typedef enum _tai_network_interface_attr_t
      * Set to 0 to use NVR value
      *
      * @type #tai_uint64_t
+     * @flags CREATE_AND_SET
+     * @default vendor-specific
      */
     TAI_NETWORK_INTERFACE_ATTR_CH1_FREQ,
 

--- a/meta/test/test.c
+++ b/meta/test/test.c
@@ -55,9 +55,9 @@ int test5() {
     tai_serialize_option_t option = {
         .human = true,
     };
-    ret = tai_deserialize_network_interface_attr("tx-channel", &value, &option);
+    ret = tai_deserialize_network_interface_attr("tx-laser-freq", &value, &option);
     printf("%d, %d\n", value, ret);
-    return 0;
+    return ret;
 }
 
 int main() {
@@ -79,7 +79,15 @@ int main() {
     ret = test3(buf);
     printf("%s, %d\n", buf, ret);
 
-    test4();
+    ret = test4();
+    if ( ret < 0 ) {
+        return ret;
+    }
 
-    test5();
+    ret = test5();
+    if ( ret < 0 ) {
+        return ret;
+    }
+
+    return 0;
 }

--- a/tools/taish/lib/server.cpp
+++ b/tools/taish/lib/server.cpp
@@ -232,7 +232,11 @@ static void convert_metadata(const tai_attr_metadata_t* const src, ::tai::Attrib
     dst->set_object_type(static_cast<tai::TAIObjectType>(src->objecttype));
     auto u = dst->mutable_usage();
     usage(src, u);
-    dst->set_is_readonly((src->flags & TAI_ATTR_FLAGS_READ_ONLY) > 0);
+    dst->set_is_readonly(src->isreadonly);
+    dst->set_is_mandatoryoncreate(src->ismandatoryoncreate);
+    dst->set_is_createonly(src->iscreateonly);
+    dst->set_is_createandset(src->iscreateandset);
+    dst->set_is_key(src->iskey);
 }
 
 ::grpc::Status TAIServiceImpl::ListAttributeMetadata(::grpc::ServerContext* context, const ::tai::ListAttributeMetadataRequest* request, ::grpc::ServerWriter< ::tai::ListAttributeMetadataResponse>* writer) {

--- a/tools/taish/proto/tai.proto
+++ b/tools/taish/proto/tai.proto
@@ -73,6 +73,10 @@ message AttributeMetadata {
     TAIObjectType object_type = 4;
     string usage = 5;
     bool is_readonly = 6;
+    bool is_mandatoryoncreate = 7;
+    bool is_createonly = 8;
+    bool is_createandset = 9;
+    bool is_key = 10;
 }
 
 message HostInterface {


### PR DESCRIPTION
This PR adds support to parse `@default` command in TAI headers when generating the meta library.

The default value can be accessed via `tai_attr_metadata_t`.