### PR TITLE
add notification infrastructure and generic netif notification attribute

### DIFF
--- a/inc/tainetworkif.h
+++ b/inc/tainetworkif.h
@@ -506,6 +506,15 @@ typedef enum _tai_network_interface_attr_t
     TAI_NETWORK_INTERFACE_ATTR_CURRENT_PRBS_BER,
 
     /**
+     * @brief Network interface generic notification
+     *
+     * @type #tai_notification_handler_t
+     * @flags CREATE_AND_SET
+     * @default NULL
+     */
+    TAI_NETWORK_INTERFACE_ATTR_NOTIFY,
+
+    /**
      * @brief End of attributes
      */
     TAI_NETWORK_INTERFACE_ATTR_END,

--- a/inc/taitypes.h
+++ b/inc/taitypes.h
@@ -212,6 +212,36 @@ typedef struct _tai_attr_value_list_t
     uint32_t _alloced;
 } tai_attr_value_list_t;
 
+// Forward declaration of tai_attribute_t for tai_notification_fn
+struct _tai_attribute_t;
+typedef struct _tai_attribute_t tai_attribute_t;
+
+/**
+ * @brief TAI notification callback
+ *
+ * @param[in] context User context
+ * @param[in] oid object ID
+ * @param[in] attribute Updated attribute
+ */
+typedef void (*tai_notification_fn)(
+        _In_ void* context,
+        _In_ tai_object_id_t oid,
+        _In_ tai_attribute_t const * const attribute);
+
+/**
+ * @brief TAI notification handler
+ *
+ * Generic notification handler which can be used by any TAI objects
+ *
+ * The handler will be set by TAI adapter host by using TAI attribute
+ * whose value type must be #tai_pointer_t #tai_notification_handler_t
+ *
+ */
+typedef struct _tai_notification_handler_t {
+    void* context;
+    tai_notification_fn notify;
+} tai_notification_handler_t;
+
 /**
  * @brief Data Type
  *
@@ -245,7 +275,7 @@ typedef union _tai_attribute_value_t
     tai_s32_range_t s32range;
     tai_object_map_list_t objmaplist;
     tai_attr_value_list_t attrlist;
-
+    tai_notification_handler_t notification;
 } tai_attribute_value_t;
 
 typedef struct _tai_attribute_t

--- a/meta/taimetadatatypes.h
+++ b/meta/taimetadatatypes.h
@@ -180,6 +180,11 @@ typedef enum _tai_attr_value_type_t
      */
     TAI_ATTR_VALUE_TYPE_ATTRLIST,
 
+    /*
+     * @brief Attribute value is notification handler.
+     */
+    TAI_ATTR_VALUE_TYPE_NOTIFICATION,
+
 } tai_attr_value_type_t;
 
 /**

--- a/meta/taimetadatautils.c
+++ b/meta/taimetadatautils.c
@@ -383,6 +383,7 @@ tai_status_t _tai_metadata_free_attr_value(
     case TAI_ATTR_VALUE_TYPE_OID:
     case TAI_ATTR_VALUE_TYPE_U32RANGE:
     case TAI_ATTR_VALUE_TYPE_S32RANGE:
+    case TAI_ATTR_VALUE_TYPE_NOTIFICATION:
         return TAI_STATUS_SUCCESS;
     case TAI_ATTR_VALUE_TYPE_OBJLIST:
         _TAI_META_FREE_LIST(objlist);
@@ -455,6 +456,7 @@ static int _tai_list_size(
     case TAI_ATTR_VALUE_TYPE_OID:
     case TAI_ATTR_VALUE_TYPE_U32RANGE:
     case TAI_ATTR_VALUE_TYPE_S32RANGE:
+    case TAI_ATTR_VALUE_TYPE_NOTIFICATION:
         return 0;
     case TAI_ATTR_VALUE_TYPE_OBJLIST:
         return value->objlist.count;
@@ -522,6 +524,7 @@ static tai_status_t _tai_metadata_alloc_attr_value(
     case TAI_ATTR_VALUE_TYPE_OID:
     case TAI_ATTR_VALUE_TYPE_U32RANGE:
     case TAI_ATTR_VALUE_TYPE_S32RANGE:
+    case TAI_ATTR_VALUE_TYPE_NOTIFICATION:
         return TAI_STATUS_SUCCESS;
     case TAI_ATTR_VALUE_TYPE_OBJLIST:
         _TAI_META_ALLOC_LIST(objlist, tai_object_id_t);
@@ -636,6 +639,7 @@ static tai_status_t _tai_metadata_deepcopy_attr_value(
     case TAI_ATTR_VALUE_TYPE_OID:
     case TAI_ATTR_VALUE_TYPE_U32RANGE:
     case TAI_ATTR_VALUE_TYPE_S32RANGE:
+    case TAI_ATTR_VALUE_TYPE_NOTIFICATION:
         memcpy(out, in, sizeof(tai_attribute_value_t));
         break;
     case TAI_ATTR_VALUE_TYPE_OBJLIST:

--- a/meta/taiserialize.c
+++ b/meta/taiserialize.c
@@ -533,6 +533,14 @@ int tai_serialize_object_id(
     return snprintf(buffer, n, "oid:0x%lx", oid);
 }
 
+int tai_serialize_pointer(
+        _Out_ char *buffer,
+        _In_ size_t n,
+        _In_ tai_pointer_t ptr)
+{
+    return snprintf(buffer, n, "%p", ptr);
+}
+
 int tai_deserialize_object_id(
         _In_ const char *buffer,
         _Out_ tai_object_id_t *oid)
@@ -722,8 +730,7 @@ int tai_serialize_attribute_value(
     case TAI_ATTR_VALUE_TYPE_FLT:
         return tai_serialize_float(ptr, n, value->flt);
     case TAI_ATTR_VALUE_TYPE_PTR:
-        TAI_META_LOG_WARN("pointer serialization is not implemented");
-        return TAI_SERIALIZE_ERROR;
+        return tai_serialize_pointer(ptr, n, value->ptr);
     case TAI_ATTR_VALUE_TYPE_OID:
         return tai_serialize_object_id(ptr, n, value->oid);
     case TAI_ATTR_VALUE_TYPE_OBJLIST:
@@ -922,7 +929,7 @@ int tai_deserialize_attribute_value(
     case TAI_ATTR_VALUE_TYPE_FLT:
         return tai_deserialize_float(buffer, &value->flt);
     case TAI_ATTR_VALUE_TYPE_PTR:
-        TAI_META_LOG_WARN("pointer serialization is not implemented");
+        TAI_META_LOG_WARN("pointer deserialization is not implemented");
         return TAI_SERIALIZE_ERROR;
     case TAI_ATTR_VALUE_TYPE_U32RANGE:
         return tai_deserialize_u32range(buffer, &value->u32range);

--- a/meta/taiserialize.c
+++ b/meta/taiserialize.c
@@ -731,6 +731,13 @@ int tai_serialize_attribute_value(
         return tai_serialize_float(ptr, n, value->flt);
     case TAI_ATTR_VALUE_TYPE_PTR:
         return tai_serialize_pointer(ptr, n, value->ptr);
+    case TAI_ATTR_VALUE_TYPE_NOTIFICATION:
+        _SERIALIZE(snprintf(ptr, n, "{ \"context\": \""), count, ptr, n);
+        _SERIALIZE(tai_serialize_pointer(ptr, n, value->notification.context), count, ptr, n);
+        _SERIALIZE(snprintf(ptr, n, "\", \"notify\": \""), count, ptr, n);
+        _SERIALIZE(tai_serialize_pointer(ptr, n, value->notification.notify), count, ptr, n);
+        _SERIALIZE(snprintf(ptr, n, "\"}"), count, ptr, n);
+        return ptr - buffer;
     case TAI_ATTR_VALUE_TYPE_OID:
         return tai_serialize_object_id(ptr, n, value->oid);
     case TAI_ATTR_VALUE_TYPE_OBJLIST:

--- a/tools/taish/Makefile
+++ b/tools/taish/Makefile
@@ -23,8 +23,12 @@ lib: proto $(LIB_OBJS)
 .cpp.o:
 	$(CC) $(CFLAGS) $(INCLUDE) -c -o $@ $<
 
-proto: proto/tai.proto
+proto: lib/tai.grpc.pb.cc lib/tai.grpc.pb.h lib/tai.pb.cc lib/tai.pb.h
+
+lib/tai.pb.cc lib/tai.pb.h: proto/tai.proto
 	protoc --cpp_out=./lib -I proto tai.proto
+
+lib/tai.grpc.pb.cc lib/tai.grpc.pb.h: proto/tai.proto
 	protoc --grpc_out=./lib --plugin=protoc-gen-grpc=`which grpc_cpp_plugin` -I proto tai.proto
 
 docker:

--- a/tools/taish/client/taish.py
+++ b/tools/taish/client/taish.py
@@ -226,13 +226,9 @@ class TAIShellCompleter(Completer):
         return
 
 
-def loop(stub, modules):
+def loop(stub, modules, module, netif, hostif):
 
-    module = None
-    netif = None
-    hostif = None
     session = PromptSession()
-
 
     while True:
         p = "> "
@@ -338,38 +334,40 @@ def main():
                 print('specify a reachable host by using --addr option')
             sys.exit(1)
 
-        if len(args) == 0:
-            loop(stub, modules)
-
-        if args[0] == 'list':
-            show_modules(modules)
-            return
-
-        if options.module == None:
-            options.module = list(modules.keys())[0]
-
-        if options.module not in modules:
-            print('no module whose location is {}'.format(options.module))
-            return
-        module = modules[options.module]
+        module = None
+        if options.module != None:
+            if options.module not in modules:
+                print('no module whose location is {}'.format(options.module))
+                return
+            module = modules[options.module]
 
         if options.netif != None and options.hostif != None:
             print('can\'t specify both netif and hostif')
             return
 
         netif = None
-        if options.netif != None:
+        if module != None and options.netif != None:
             if len(module.netifs) <= options.netif:
                 print('invalid index: len: {}'.format(len(module.netifs)))
                 return
             netif = module.netifs[options.netif]
 
         hostif = None
-        if options.hostif != None:
+        if module != None and options.hostif != None:
             if len(module.hostifs) <= options.hostif:
                 print('invalid index: len: {}'.format(len(module.hostifs)))
                 return
             hostif = module.hostifs[options.hostif]
+
+        if len(args) == 0:
+            loop(stub, modules, module, netif, hostif)
+
+        if args[0] == 'list':
+            show_modules(modules)
+            return
+
+        if module == None:
+            module = modules.values()[0]
 
         if args[0] == 'list-attr':
             list_attr(stub, module, netif, hostif)

--- a/tools/taish/proto/tai.proto
+++ b/tools/taish/proto/tai.proto
@@ -8,6 +8,7 @@ service TAI {
     rpc GetAttributeMetadata(GetAttributeMetadataRequest) returns (GetAttributeMetadataResponse);
     rpc GetAttribute(GetAttributeRequest) returns (GetAttributeResponse);
     rpc SetAttribute(SetAttributeRequest) returns (SetAttributeResponse);
+    rpc Monitor(MonitorRequest) returns (stream MonitorResponse);
 }
 
 enum TAIObjectType {
@@ -59,6 +60,14 @@ message SetAttributeRequest {
 }
 
 message SetAttributeResponse {
+}
+
+message MonitorRequest {
+    uint64 oid = 1;
+}
+
+message MonitorResponse {
+    Attribute attribute = 1;
 }
 
 message Attribute {


### PR DESCRIPTION
This PR adds notification infrastructure which can be used by all TAI objects to implement performance monitoring or alarm notification etc..

The attribute value type `tai_notification_handler_t` is added to pass a user context whose type is `void*` and a callback function.

We can define a TAI attribute whose attribute value type is `tai_notification_handler_t` to add notification feature in TAI.

The function signature of the callback function is 

```c
typedef void (*tai_notification_fn)(
        _In_ void* context,
        _In_ tai_object_id_t oid,
        _In_ tai_attribute_t const * const attribute)
```

When calling this callback, TAI adapter (TAI library) sets the context which is passed via `tai_notification_handler_t` as the 1st argument. 2nd argument `oid` is the object ID of the object which emits the notification. 3rd argument `attribute` contains the notification content. We can use the existing TAI attributes as notification content.

As the first TAI attribute which uses this infrastructure, `TAI_NETWORK_INTERFACE_ATTR_NOTIFY` is added. This attribute is intended to get generic notifications for a specific network interface.
It is up to the TAI adapter implementer what to notify.

One example of the usage is the state change of the network interface.
The callback can be called whenever `TAI_NETWORK_INTERFACE_ATTR_OPER_STATUS` / `TAI_NETWORK_INTERFACE_ATTR_RX_OTU_STATUS` is changed to work as alarm notification or it can be called periodically to notify `TAI_NETWORK_INTERFACE_ATTR_CURRENT_PRE_FEC_BER` to work as performance monitoring.

This PR also enhances `taish` to use this notification infrastructure.

`taish monitor` command is added to monitor the notification.
Currently, only monitoring `TAI_NETWORK_INTERFACE_ATTR_NOTIFY` is supported.