### PR TITLE
Fix wrong description about license in each files and add NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,3 @@
+This source code includes following software
+
+- SAI : licensed by Microsoft under the Apache License, Version 2.0

--- a/inc/tai.h
+++ b/inc/tai.h
@@ -6,24 +6,14 @@
  * @copyright Copyright (c) 2014 Microsoft Open Technologies, Inc.
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
  * @copyright Copyright (c) 2017 Cumulus Networks, Inc.
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ * This source code includes software licensed by Microsoft under the
+ * Apache License, Version 2.0
  *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
- * @remark  Microsoft would like to thank the following companies for their
- *          review and assistance with these files: Intel Corporation, Mellanox
- *          Technologies Ltd, Dell Products, L.P., Facebook, Inc., Marvell
- *          International Ltd.
  */
 
 #if !defined (__TAI_H_)

--- a/inc/taihostif.h
+++ b/inc/taihostif.h
@@ -6,24 +6,11 @@
  * @copyright Copyright (c) 2014 Microsoft Open Technologies, Inc.
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
  * @copyright Copyright (c) 2017 Cumulus Networks, Inc.
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
- *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
- * @remark  Microsoft would like to thank the following companies for their
- *          review and assistance with these files: Intel Corporation, Mellanox
- *          Technologies Ltd, Dell Products, L.P., Facebook, Inc., Marvell
- *          International Ltd.
  */
 
 #if !defined (__TAIHOSTIF_H_)

--- a/inc/taimodule.h
+++ b/inc/taimodule.h
@@ -8,24 +8,11 @@
  * @copyright Copyright (c) 2014 Microsoft Open Technologies, Inc.
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
  * @copyright Copyright (c) 2017 Cumulus Networks, Inc.
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
- *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
- * @remark  Microsoft would like to thank the following companies for their
- *          review and assistance with these files: Intel Corporation, Mellanox
- *          Technologies Ltd, Dell Products, L.P., Facebook, Inc., Marvell
- *          International Ltd.
  */
 
 #if !defined (__TAIMODULE_H_)

--- a/inc/tainetworkif.h
+++ b/inc/tainetworkif.h
@@ -6,24 +6,11 @@
  * @copyright Copyright (c) 2014 Microsoft Open Technologies, Inc.
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
  * @copyright Copyright (c) 2017 Cumulus Networks, Inc.
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
- *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
- * @remark  Microsoft would like to thank the following companies for their
- *          review and assistance with these files: Intel Corporation, Mellanox
- *          Technologies Ltd, Dell Products, L.P., Facebook, Inc., Marvell
- *          International Ltd.
  */
 
 #if !defined (__TAINETWORKIF_H_)

--- a/inc/taistatus.h
+++ b/inc/taistatus.h
@@ -6,24 +6,14 @@
  * @copyright Copyright (c) 2014 Microsoft Open Technologies, Inc.
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
  * @copyright Copyright (c) 2017 Cumulus Networks, Inc.
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ * This source code includes software licensed by Microsoft under the
+ * Apache License, Version 2.0
  *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
- * @remark  Microsoft would like to thank the following companies for their
- *          review and assistance with these files: Intel Corporation, Mellanox
- *          Technologies Ltd, Dell Products, L.P., Facebook, Inc., Marvell
- *          International Ltd.
  */
 
 #if !defined (__TAISTATUS_H_)

--- a/inc/taitypes.h
+++ b/inc/taitypes.h
@@ -5,24 +5,14 @@
  * @copyright Copyright (c) 2014 Microsoft Open Technologies, Inc.
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
  * @copyright Copyright (c) 2017 Cumulus Networks, Inc.
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ * This source code includes software licensed by Microsoft under the
+ * Apache License, Version 2.0
  *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
- * @remark  Microsoft would like to thank the following companies for their
- *          review and assistance with these files: Intel Corporation, Mellanox
- *          Technologies Ltd, Dell Products, L.P., Facebook, Inc., Marvell
- *          International Ltd.
  */
 
 #if !defined (__TAITYPES_H_)

--- a/meta/main.py
+++ b/meta/main.py
@@ -1,18 +1,9 @@
 #
-# Copyright (C) 2018 Nippon Telegraph and Telephone Corporation.
+# Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
+# All rights reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
 import sys
 

--- a/meta/taimetadatalogger.h
+++ b/meta/taimetadatalogger.h
@@ -5,24 +5,14 @@
  *
  * @copyright Copyright (c) 2014 Microsoft Open Technologies, Inc.
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ * This source code includes software licensed by Microsoft under the
+ * Apache License, Version 2.0
  *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
- * @remark  Microsoft would like to thank the following companies for their
- *          review and assistance with these files: Intel Corporation, Mellanox
- *          Technologies Ltd, Dell Products, L.P., Facebook, Inc., Marvell
- *          International Ltd.
  */
 
 #ifndef __TAIMETADATALOGGER_H_

--- a/meta/taimetadatatypes.h
+++ b/meta/taimetadatatypes.h
@@ -5,24 +5,14 @@
  *
  * @copyright Copyright (c) 2014 Microsoft Open Technologies, Inc.
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ * This source code includes software licensed by Microsoft under the
+ * Apache License, Version 2.0
  *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
- * @remark  Microsoft would like to thank the following companies for their
- *          review and assistance with these files: Intel Corporation, Mellanox
- *          Technologies Ltd, Dell Products, L.P., Facebook, Inc., Marvell
- *          International Ltd.
  */
 
 #ifndef __TAIMETADATATYPES_H_

--- a/meta/taimetadatautils.c
+++ b/meta/taimetadatautils.c
@@ -5,24 +5,14 @@
  *
  * @copyright Copyright (c) 2014 Microsoft Open Technologies, Inc.
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ * This source code includes software licensed by Microsoft under the
+ * Apache License, Version 2.0
  *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
- * @remark  Microsoft would like to thank the following companies for their
- *          review and assistance with these files: Intel Corporation, Mellanox
- *          Technologies Ltd, Dell Products, L.P., Facebook, Inc., Marvell
- *          International Ltd.
  */
 
 #include <stdio.h>

--- a/meta/taimetadatautils.h
+++ b/meta/taimetadatautils.h
@@ -5,24 +5,14 @@
  *
  * @copyright Copyright (c) 2014 Microsoft Open Technologies, Inc.
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ * This source code includes software licensed by Microsoft under the
+ * Apache License, Version 2.0
  *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
- * @remark  Microsoft would like to thank the following companies for their
- *          review and assistance with these files: Intel Corporation, Mellanox
- *          Technologies Ltd, Dell Products, L.P., Facebook, Inc., Marvell
- *          International Ltd.
  */
 
 #ifndef __TAIMETADATAUTILS_H_

--- a/meta/taiserialize.c
+++ b/meta/taiserialize.c
@@ -6,24 +6,14 @@
  *
  * @copyright Copyright (c) 2014 Microsoft Open Technologies, Inc.
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ * This source code includes software licensed by Microsoft under the
+ * Apache License, Version 2.0
  *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
- * @remark  Microsoft would like to thank the following companies for their
- *          review and assistance with these files: Intel Corporation, Mellanox
- *          Technologies Ltd, Dell Products, L.P., Facebook, Inc., Marvell
- *          International Ltd.
  */
 
 #include <arpa/inet.h>

--- a/meta/taiserialize.h
+++ b/meta/taiserialize.h
@@ -5,24 +5,14 @@
  *
  * @copyright Copyright (c) 2014 Microsoft Open Technologies, Inc.
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+ * This source code includes software licensed by Microsoft under the
+ * Apache License, Version 2.0
  *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
- * @remark  Microsoft would like to thank the following companies for their
- *          review and assistance with these files: Intel Corporation, Mellanox
- *          Technologies Ltd, Dell Products, L.P., Facebook, Inc., Marvell
- *          International Ltd.
  */
 
 #ifndef __TAISERIALIZE_H_

--- a/stub/stub_tai.c
+++ b/stub/stub_tai.c
@@ -4,21 +4,12 @@
  *  @author  Scott Emery <scotte@cumulusnetworks.com>
  *
  *  @copyright Copyright (C) 2018 Cumulus Networks, Inc. All rights reserved
+ *  @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
+ *  All rights reserved.
  *
- *  @copyright Copyright (C) 2018 Cumulus Networks, Inc. All rights reserved
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
  *
- *  @remark  Licensed under the Apache License, Version 2.0 (the "License"); you 
- *           may not use this file except in compliance with the License. You may
- *           obtain a copy of the License at
- *           http://www.apache.org/licenses/LICENSE-2.0
- *
- *  @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR 
- *           CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *           LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *           FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
- *
- *  @remark  See the Apache Version 2.0 License for specific language governing
- *           permissions and limitations under the License.
  */
 
 

--- a/tools/taish/client/taish.py
+++ b/tools/taish/client/taish.py
@@ -2,18 +2,8 @@
 #
 # Copyright (C) 2018 Nippon Telegraph and Telephone Corporation.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
 import grpc
 import sys

--- a/tools/taish/include/taigrpc.hpp
+++ b/tools/taish/include/taigrpc.hpp
@@ -5,19 +5,8 @@
  *
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
- *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
- *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #ifndef __TAIGRPC_HPP__

--- a/tools/taish/lib/server.cpp
+++ b/tools/taish/lib/server.cpp
@@ -4,19 +4,10 @@
  * @brief   This module implements TAI gRPC server
  *
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
- *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
- *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  *
  */
 

--- a/tools/taish/server/main.cpp
+++ b/tools/taish/server/main.cpp
@@ -4,20 +4,10 @@
  * @brief   This module implements taish server
  *
  * @copyright Copyright (c) 2018 Nippon Telegraph and Telephone Corporation
+ * All rights reserved.
  *
- * @remark  Licensed under the Apache License, Version 2.0 (the "License"); you
- *          may not use this file except in compliance with the License. You may
- *          obtain a copy of the License at
- *          http://www.apache.org/licenses/LICENSE-2.0
- *
- * @remark  THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
- *          CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
- *          LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
- *          FOR A PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
- *
- * @remark  See the Apache Version 2.0 License for specific language governing
- *          permissions and limitations under the License.
- *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 #include "taigrpc.hpp"


### PR DESCRIPTION
TAI is licensed under BSD 3-Clause License. Fix the description in each
files which were taken from SAI.
Also mention about SAI license (Apache License, Version 2.0).

related: #4

Signed-off-by: Wataru Ishida <ishida@nel-america.com>