### PR TITLE
netif: add SNR attribute

### DIFF
--- a/inc/tainetworkif.h
+++ b/inc/tainetworkif.h
@@ -473,7 +473,17 @@ typedef enum _tai_network_interface_attr_t
      * @flags READ_ONLY
      */
     TAI_NETWORK_INTERFACE_ATTR_CURRENT_DIFFERENTIAL_GROUP_DELAY,
-
+    
+    /**
+     * @brief Current Signal-to-Noise Ratio (SNR) in dB
+     *
+     * @reference CFP MSA BA00
+     *
+     * @type #tai_float_t
+     * @flags READ_ONLY
+     */
+    TAI_NETWORK_INTERFACE_ATTR_CURRENT_SNR,
+    
     /**
      * @brief The current post-FEC bit error rate
      *


### PR DESCRIPTION
I propose to add read-only attribute TAI_NETWORK_INTERFACE_ATTR_CURRENT_SNR in reference to CFP MSA, similar to #67.