### PR TITLE
framework: don't call a set_hook when caching attributes for alarm

### DIFF
--- a/tools/framework/config.hpp
+++ b/tools/framework/config.hpp
@@ -155,16 +155,16 @@ namespace tai::framework {
                 return _set(src, false, without_hook);
             }
 
-            tai_status_t set_readonly(S_Attribute src) {
-                return _set(src, true, false);
+            tai_status_t set_readonly(S_Attribute src, bool without_hook = false) {
+                return _set(src, true, without_hook);
             }
 
             tai_status_t set(const tai_attribute_t& src, bool without_hook = false) {
                 return _set(src, false, without_hook);
             }
 
-            tai_status_t set_readonly(const tai_attribute_t& src) {
-                return _set(src, true, false);
+            tai_status_t set_readonly(const tai_attribute_t& src, bool without_hook = false) {
+                return _set(src, true, without_hook);
             }
 
             tai_status_t get_attributes(uint32_t attr_count, tai_attribute_t * const attr_list) {

--- a/tools/framework/object.hpp
+++ b/tools/framework/object.hpp
@@ -159,11 +159,11 @@ namespace tai::framework {
                 attrs.emplace_back(*attr->raw());
                 if ( alarm ) {
                     if ( meta->isreadonly ) {
-                        if ( (ret = m_alarm_cache.set_readonly(attr)) < 0 ) {
+                        if ( (ret = m_alarm_cache.set_readonly(attr, true)) < 0 ) {
                             return ret;
                         }
                     } else {
-                        if ( (ret = m_alarm_cache.set(attr)) < 0 ) {
+                        if ( (ret = m_alarm_cache.set(attr, true)) < 0 ) {
                             return ret;
                         }
                     }


### PR DESCRIPTION
m_alarm_cache is used to *compare* an attribute which is already sent
and an attribute which is going to be sent.

We don't neet to call a set_hook for this purpose

Signed-off-by: Wataru Ishida <ishida@nel-america.com>