### PR TITLE
taish: don't close the gRPC channel in the destructor

### DIFF
--- a/tools/taish/client/taish/__init__.py
+++ b/tools/taish/client/taish/__init__.py
@@ -121,9 +121,6 @@ class AsyncClient(object):
     def close(self):
         self.channel.close()
 
-    def __del__(self):
-        self.close()
-
     def __enter__(self):
         return self
 


### PR DESCRIPTION
the event loop can be already closed when the destructor is called

Signed-off-by: Wataru Ishida <wataru.ishid@gmail.com>