### PR TITLE
add meta APIs to TAI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,5 @@ jobs:
           with:
               version: latest
         - uses: actions/checkout@v2
-        - run: make builder
+        - run: make ci
         - run: make image

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ builder:
 bash:
 	$(MAKE) cmd
 
+ci: builder
+	TAI_DOCKER_RUN_OPTION='--rm' TAI_DOCKER_CMD="make test" $(MAKE) cmd
+
 clean:
 	$(MAKE) -C ./meta clean
 	$(MAKE) -C ./stub clean

--- a/inc/tai.h
+++ b/inc/tai.h
@@ -28,6 +28,7 @@ extern "C" {
 #include "tainetworkif.h"
 #include "taistatus.h"
 #include "taitypes.h"
+#include "taimeta.h"
 
 /**
  * @defgroup TAI TAI - Entry point specific API definitions.
@@ -48,6 +49,7 @@ typedef enum _tai_api_t
     TAI_API_MODULE,             /**< #tai_module_api_t */
     TAI_API_HOSTIF,             /**< #tai_host_interface_api_t */
     TAI_API_NETWORKIF,          /**< #tai_network_interface_api_t */
+    TAI_API_META     ,          /**< #tai_meta_api_t */
     TAI_API_MAX                 /**< total number of APIs */
 } tai_api_t;
 

--- a/inc/taimeta.h
+++ b/inc/taimeta.h
@@ -1,0 +1,80 @@
+/**
+ * @file    taimeta.h
+ * @brief   This module defines the meta interface for the Transponder
+ *          Abstraction Interface (TAI)
+ *
+ * @copyright Copyright (c) 2021 Nippon Telegraph and Telephone Corporation
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+#if !defined (__TAIMETA_H_)
+#define __TAIMETA_H_
+
+#include <taitypes.h>
+#include <taimetadatatypes.h>
+
+/**
+ * @defgroup TAIMETA TAI - Meta specific API definitions
+ *
+ * @{
+ */
+
+/**
+ * @brief List metadata of the given oid object
+ *
+ * Passing TAI_NULL_OBJECT_ID to oid and TAI_OBJECT_TYPE_NULL to object_type
+ * returns all metadata which this TAI library has.
+ *
+ * @param[in] key Metadata key
+ * @param[out] count Number of metadata
+ * @param[out] list Array of metadata
+ *
+ * @return #TAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef tai_status_t (*tai_meta_list_metadata_fn)(
+        _In_ const tai_metadata_key_t *const key,
+        _Out_ uint32_t *count,
+        _Out_ const tai_attr_metadata_t * const **list);
+
+/**
+ * @brief Get attribute metadata of the given oid object
+ *
+ * @param[in] key Metadata key
+ * @param[in] attr_id Attribute Id
+ *
+ * @return Pointer to attribute metadata or NULL in case of failure
+ */
+typedef const tai_attr_metadata_t* (*tai_meta_get_attr_metadata_fn)(
+        _In_ const tai_metadata_key_t *const key,
+        _In_ tai_attr_id_t attr_id);
+
+/**
+ * @brief Get object info of the given oid object
+ *
+ * @param[in] key Metadata key
+ *
+ * @return Pointer to object metadata or NULL in case of failure
+ */
+typedef const tai_object_type_info_t* (*tai_meta_get_object_info_fn)(
+        _In_ const tai_metadata_key_t *const key);
+
+/**
+ * @brief Meta methods table retrieved with tai_api_query()
+ */
+typedef struct _tai_meta_api_t
+{
+    tai_meta_list_metadata_fn               list_metadata;
+    tai_meta_get_attr_metadata_fn           get_attr_metadata;
+    tai_meta_get_object_info_fn             get_object_info;
+} tai_meta_api_t;
+
+/**
+ * @}
+ */
+
+
+#endif /** __TAIMETA_H_ */

--- a/inc/taimetadatatypes.h
+++ b/inc/taimetadatatypes.h
@@ -18,6 +18,8 @@
 #ifndef __TAIMETADATATYPES_H_
 #define __TAIMETADATATYPES_H_
 
+#include "taitypes.h"
+
 /**
  * @defgroup TAIMETADATATYPES TAI - Metadata Types Definitions
  *
@@ -930,6 +932,12 @@ typedef struct _tai_object_type_info_t
     size_t                                          revgraphmemberscount;
 
 } tai_object_type_info_t;
+
+typedef struct _tai_metadata_key_t {
+    tai_object_id_t oid;
+    tai_object_type_t type;
+    tai_char_list_t location;
+} tai_metadata_key_t;
 
 /**
  * @}

--- a/meta/taimetadatautils.c
+++ b/meta/taimetadatautils.c
@@ -77,7 +77,7 @@ const tai_attr_metadata_t* tai_metadata_get_attr_metadata(
         const tai_attr_metadata_t* const* const md = tai_metadata_attr_by_object_type[objecttype];
 
         /*
-         * Most obejct attributes are not flags, so we can use direct index to
+         * Most object attributes are not flags, so we can use direct index to
          * find attribute metadata, this should speed up search.
          */
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,7 +11,7 @@ ifndef TAI_TAISH_SERVER
 endif
 
 ifndef LD_LIBRARY_PATH
-    LD_LIBRARY_PATH := ../meta:$(dir $(TAI_TEST_TARGET))
+    LD_LIBRARY_PATH := $(dir $(TAI_TEST_TARGET))
 endif
 
 .PHONY: all c python
@@ -21,8 +21,8 @@ all: c python
 ../meta/libmetatai.so:
 	$(MAKE) -C $(@D)
 
-c: $(TAI_TEST_TARGET) ../meta/libmetatai.so
-	gcc -I ../inc -I ../sai/inc -o test test.c -L $(dir $(TAI_TEST_TARGET)) -ltai -L ../meta -lmetatai
+c: $(TAI_TEST_TARGET)
+	gcc -I ../inc -o test test.c -L $(dir $(TAI_TEST_TARGET)) -ltai
 	LD_LIBRARY_PATH=$(LD_LIBRARY_PATH) ./test
 
 python: taish $(TAI_TAISH_SERVER) $(TAI_TEST_TARGET)

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,0 +1,8 @@
+{
+    "0": {
+        "attrs": {
+            "admin-status": "down",
+            "custom": true
+        }
+    }
+}

--- a/tools/framework/examples/basic/Makefile
+++ b/tools/framework/examples/basic/Makefile
@@ -4,10 +4,15 @@ TAI_DIR := ../../../../
 TAI_FRAMEWORK_DIR := $(TAI_DIR)/tools/framework
 TAI_LIB_DIR := $(TAI_DIR)/tools/lib
 
-SRCS := basic.cpp $(wildcard $(TAI_LIB_DIR)/*.cpp) $(wildcard $(TAI_FRAMEWORK_DIR)/*.cpp)
+SRCS = basic.cpp $(wildcard $(TAI_LIB_DIR)/*.cpp) $(wildcard $(TAI_FRAMEWORK_DIR)/*.cpp) $(wildcard $(TAI_DIR)/meta/*.c)
+
+BUILD_DIR ?= build
+
+OBJS = $(addsuffix .o,$(basename $(SRCS)))
+
 HEADERS := basic.hpp $(wildcard $(TAI_LIB_DIR)/*.hpp) $(wildcard $(TAI_FRAMEWORK_DIR)/*.hpp)
 
-INCLUDE := -I $(TAI_DIR)/inc -I $(TAI_DIR)/meta -I $(TAI_LIB_DIR) -I $(TAI_FRAMEWORK_DIR) -include basic.hpp
+INCLUDE := -I $(TAI_DIR)/inc -I $(TAI_DIR)/meta -I $(TAI_LIB_DIR) -I $(TAI_FRAMEWORK_DIR)
 # -fno-gnu-unique
 # tai::Logger::get_instance() is an inline method of Logger and it returns a static Logger.
 # when the library is used under tai-mux which uses dlopen(), we want to make the logger per library not globally unique
@@ -15,12 +20,25 @@ INCLUDE := -I $(TAI_DIR)/inc -I $(TAI_DIR)/meta -I $(TAI_LIB_DIR) -I $(TAI_FRAME
 # ref) https://stackoverflow.com/questions/38510621/destructor-of-a-global-static-variable-in-a-shared-library-is-not-called-on-dlcl
 #
 # Alternative solution is to make tai::Logger::get_instance() non-inline ( implement it in a cpp file )
-CFLAGS := -std=c++17 -g3 -shared -fPIC -DTAI_EXPOSE_PLATFORM -fno-gnu-unique
+LDFLAGS ?= -shared -fPIC -fno-gnu-unique
 
-LIBS := -L $(TAI_DIR)/meta -lmetatai -lpthread
+CFLAGS ?= -fPIC -fno-gnu-unique -DTAI_EXPOSE_PLATFORM $(INCLUDE) -Bsymbolic
 
-${PROG}: ${SRCS} ${HEADERS} Makefile
-	$(CXX) ${CFLAGS} -o $@ ${INCLUDE} ${SRCS} ${LIBS}
+CXXFLAGS ?= $(CFLAGS) -std=c++17 -include basic.hpp
+
+LIBS := -lpthread
+
+
+TAI_META_CUSTOM_FILES ?= $(abspath $(wildcard custom/* $(MUX_SRCDIR)/custom_attrs/*))
+
+all: meta
+	$(MAKE) $(PROG)
+
+$(PROG): meta $(OBJS) $(HEADERS) Makefile
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
+
+meta:
+	TAI_META_CUSTOM_FILES="$(TAI_META_CUSTOM_FILES)" $(MAKE) -C $(TAI_DIR)/meta
 
 clean:
-	$(RM) ${PROG}
+	$(RM) $(PROG) $(OBJS)

--- a/tools/framework/examples/basic/basic.hpp
+++ b/tools/framework/examples/basic/basic.hpp
@@ -8,7 +8,7 @@ namespace tai::basic {
 
     using namespace tai::framework;
 
-    const uint8_t BASIC_NUM_MODULE = 1;
+    const uint8_t BASIC_NUM_MODULE = 8;
     const uint8_t BASIC_NUM_NETIF = 1;
     const uint8_t BASIC_NUM_HOSTIF = 2;
 

--- a/tools/framework/examples/basic/custom/module.h
+++ b/tools/framework/examples/basic/custom/module.h
@@ -1,0 +1,18 @@
+#ifndef __TAI_BASIC_MODULE__
+#define __TAI_BASIC_MODULE__
+
+#include <tai.h>
+
+typedef enum _basic_module_attr_t
+{
+    /**
+     * @brief Custom attribute example
+     *
+     * @type bool
+     * @flags CREATE_AND_SET
+     */
+    TAI_MODULE_ATTR_CUSTOM = TAI_MODULE_ATTR_CUSTOM_RANGE_START,
+
+} basic_module_attr_t;
+
+#endif

--- a/tools/framework/object.hpp
+++ b/tools/framework/object.hpp
@@ -13,7 +13,6 @@ namespace tai::framework {
             virtual tai_status_t get_attributes(uint32_t attr_count, tai_attribute_t* const attr_list) = 0;
             virtual tai_status_t set_attributes(uint32_t attr_count, const tai_attribute_t* const attr_list) = 0;
             virtual tai_status_t clear_attributes(uint32_t attr_count, const tai_attr_id_t* const attr_id_list) = 0;
-
     };
 
     using S_BaseObject = std::shared_ptr<BaseObject>;
@@ -38,6 +37,7 @@ namespace tai::framework {
 
             tai_status_t notify(tai_attr_id_t notification_id, const std::vector<tai_attr_id_t>& ids, bool alarm = false);
             tai_status_t notify_alarm(tai_attr_id_t notification_id, const std::vector<tai_attr_id_t>& ids);
+
 
             int clear_alarm_cache() {
                 return m_alarm_cache.clear_all();

--- a/tools/framework/platform.hpp
+++ b/tools/framework/platform.hpp
@@ -34,6 +34,38 @@ namespace tai::framework {
                 return TAI_STATUS_SUCCESS;
             }
 
+            virtual tai_status_t list_metadata(const tai_metadata_key_t *const key, uint32_t *count, const tai_attr_metadata_t *const **list) {
+                auto type = key->type;
+                if ( key->oid != TAI_NULL_OBJECT_ID ) {
+                    type = get_object_type(key->oid);
+                }
+                auto info = tai_metadata_all_object_type_infos[type];
+                if ( info == nullptr ) {
+                    *count = tai_metadata_attr_sorted_by_id_name_count;
+                    *list = tai_metadata_attr_sorted_by_id_name;
+                    return TAI_STATUS_SUCCESS;
+                }
+                *count = info->attrmetadatalength;
+                *list = info->attrmetadata;
+                return TAI_STATUS_SUCCESS;
+            }
+
+            virtual const tai_attr_metadata_t* get_attr_metadata(const tai_metadata_key_t *const key, tai_attr_id_t attr_id) {
+                auto type = key->type;
+                if ( key->oid != TAI_NULL_OBJECT_ID ) {
+                    type = get_object_type(key->oid);
+                }
+                return tai_metadata_get_attr_metadata(type, attr_id);
+            }
+
+            virtual const tai_object_type_info_t* get_object_info(const tai_metadata_key_t *const key) {
+                auto type = key->type;
+                if ( key->oid != TAI_NULL_OBJECT_ID ) {
+                    type = get_object_type(key->oid);
+                }
+                return tai_metadata_get_object_type_info(type);
+            }
+
         protected:
             const tai_service_method_table_t * m_services;
             // we don't need a lock to access m_objects/m_fsms since TAI API is not thread-safe

--- a/tools/framework/tai.cpp
+++ b/tools/framework/tai.cpp
@@ -343,6 +343,24 @@ static tai_module_api_t module_api = {
     .get_module_attributes = get_module_attributes,
 };
 
+static tai_status_t list_metadata(const tai_metadata_key_t *const key, uint32_t *count, const tai_attr_metadata_t * const **list) {
+    return g_platform->list_metadata(key, count, list);
+}
+
+static const tai_attr_metadata_t* get_attr_metadata(const tai_metadata_key_t *const key, tai_attr_id_t attr_id) {
+    return g_platform->get_attr_metadata(key, attr_id);
+}
+
+static const tai_object_type_info_t* get_object_info(const tai_metadata_key_t *const key) {
+    return g_platform->get_object_info(key);
+}
+
+static tai_meta_api_t meta_api = {
+    .list_metadata = list_metadata,
+    .get_attr_metadata  = get_attr_metadata,
+    .get_object_info = get_object_info,
+};
+
 tai_status_t tai_api_initialize(uint64_t flags, const tai_service_method_table_t* services) {
     if ( g_platform != nullptr ) {
         return TAI_STATUS_FAILURE;
@@ -383,6 +401,9 @@ tai_status_t tai_api_query(tai_api_t tai_api_id, void** api_method_table) {
         break;
     case TAI_API_HOSTIF:
         *api_method_table = &host_interface_api;
+        break;
+    case TAI_API_META:
+        *api_method_table = &meta_api;
         break;
     default:
         return TAI_STATUS_NOT_SUPPORTED;

--- a/tools/taish/Makefile
+++ b/tools/taish/Makefile
@@ -7,7 +7,7 @@ TAI_FRAMEWORK_DIR := $(TAI_DIR)/tools/framework
 TAI_BASIC_LIB_DIR := $(TAI_FRAMEWORK_DIR)/examples/basic/
 
 CFLAGS := -std=c++17 -g3 -fPIC -Wall -Werror
-LIB := `pkg-config --libs protobuf grpc++ grpc` -L ../../meta/ -lmetatai -L. -ltai
+LIB := `pkg-config --libs protobuf grpc++ grpc` -L. -ltai -L ../../meta/ -lmetatai
 INCLUDE := -I $(TAI_META_DIR) -I $(TAI_DIR)/inc -I ./include -I ./lib -I $(TAI_LIB_DIR)
 
 LIB_GRPC_SRCS := lib/taish.grpc.pb.cc lib/taish.pb.cc

--- a/tools/taish/lib/server.cpp
+++ b/tools/taish/lib/server.cpp
@@ -38,7 +38,7 @@ static void add_status(::grpc::ServerContext* context, tai_status_t status) {
 }
 
 const tai_attr_metadata_t* const get_metadata(tai_meta_api_t* meta_api, const tai_metadata_key_t * const key, tai_attr_id_t attr_id) {
-    if ( meta_api != nullptr ) {
+    if ( meta_api != nullptr && meta_api->get_attr_metadata != nullptr) {
         return meta_api->get_attr_metadata(key, attr_id);
     }
     auto type = key->type;

--- a/tools/taish/proto/taish/taish.proto
+++ b/tools/taish/proto/taish/taish.proto
@@ -53,6 +53,8 @@ message ListModuleResponse {
 
 message ListAttributeMetadataRequest {
     TAIObjectType object_type = 1;
+    uint64 oid = 2;
+    string location = 3;
 }
 
 message ListAttributeMetadataResponse {
@@ -66,6 +68,8 @@ message GetAttributeMetadataRequest {
         string attr_name = 3;
     }
     SerializeOption serialize_option = 4;
+    uint64 oid = 5;
+    string location = 6;
 }
 
 message GetAttributeMetadataResponse {

--- a/tools/taish/server/main.cpp
+++ b/tools/taish/server/main.cpp
@@ -445,6 +445,11 @@ int main(int argc, char *argv[]) {
         return -1;
     }
 
+    status = tai_api_query(TAI_API_META, (void **)(&g_api.meta_api));
+    if ( status != TAI_STATUS_SUCCESS ) {
+        std::cout << "failed to query META API: " << status << std::endl;
+    }
+
     g_api.list_module = list_module;
     g_api.object_update = object_update;
 


### PR DESCRIPTION
Unlike SAI, TAI needs to handle different kinds of devices
simultaneously. In order to support this, we have tai-mux library
which multiplexes multiple TAI libraries and provide a single TAI interface
to upper application.

However, there was no multiplex or aggregation layer for TAI *metadata*.
TAI metadata is used to know each TAI attributes characteristic and provides
utility functionality like string serialization.

Because of this lack of multiplex layer, application developers have to
create a TAI meta library by manually aggregating all TAI attributes of
TAI libraries which are planned to be used.

This is tedious, error prone works and makes it difficult to support
new TAI library dynamically.

In order to solve this issue, this commits adds meta APIs to TAI APIs.
By doing so, TAI *metadata* can be multiplexed by tai-mux just like
other APIs.

This commit also enhances TAI library framework to automatically support
the new meta APIs.

TAI library which is based on the framework will get the meta API
functionally automatically by recompiling it.

Signed-off-by: Wataru Ishida <wataru.ishid@gmail.com>