### PR TITLE
taish: make getopt work in env where char is unsigned.

### DIFF
--- a/tools/taish/server/main.cpp
+++ b/tools/taish/server/main.cpp
@@ -390,7 +390,7 @@ int main(int argc, char *argv[]) {
     auto ip = TAI_RPC_DEFAULT_IP;
     auto port = TAI_RPC_DEFAULT_PORT;
     std::string config_file;
-    char c;
+    int c;
     tai_log_level_t level = TAI_LOG_LEVEL_INFO;
     auto auto_creation = true;
 
@@ -417,7 +417,7 @@ int main(int argc, char *argv[]) {
         break;
 
       default:
-        std::cerr << "Usage: taish -i <IP address> -p <Port number> -f <Config file> -v -n" << std::endl;
+        std::cerr << "usage: " << argv[0] << "-i <IP address> -p <Port number> -f <Config file> -v -n" << std::endl;
         return 1;
       }
     }


### PR DESCRIPTION
https://stackoverflow.com/questions/17070958/c-why-does-getopt-return-255-on-linux

Signed-off-by: Wataru Ishida <wataru.ishid@gmail.com>