### PR TITLE
add TAI capability API

### DIFF
--- a/inc/taihostif.h
+++ b/inc/taihostif.h
@@ -350,6 +350,32 @@ typedef tai_status_t (*tai_clear_host_interface_attributes_fn)(
         _In_ tai_attr_id_t *attr_id);
 
 /**
+ * @brief Get host interface capability
+ *
+ * @param[in] host_interface_id Host interface id
+ * @param[inout] attr Attribute capability
+ *
+ * @return #TAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef tai_status_t (*tai_get_host_interface_capability_fn)(
+        _In_ tai_object_id_t host_interface_id,
+        _Inout_ tai_attribute_capability_t *cap);
+
+/**
+ * @brief Get multiple host interface capabilities
+ *
+ * @param[in] host_interface_id Host Interface id
+ * @param[in] count Number of capabilities
+ * @param[inout] list Attribute capabilities
+ *
+ * @return #TAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef tai_status_t (*tai_get_host_interface_capabilities_fn)(
+        _In_ tai_object_id_t host_interface_id,
+        _In_ uint32_t count,
+        _Inout_ tai_attribute_capability_t *list);
+
+/**
  * @brief Host interface methods table retrieved with tai_api_query()
  */
 typedef struct _tai_host_interface_api_t
@@ -362,6 +388,9 @@ typedef struct _tai_host_interface_api_t
     tai_get_host_interface_attributes_fn        get_host_interface_attributes;
     tai_clear_host_interface_attribute_fn       clear_host_interface_attribute;
     tai_clear_host_interface_attributes_fn      clear_host_interface_attributes;
+    tai_get_host_interface_capability_fn        get_host_interface_capability;
+    tai_get_host_interface_capabilities_fn      get_host_interface_capabilities;
+
 } tai_host_interface_api_t;
 
 /**

--- a/inc/taimodule.h
+++ b/inc/taimodule.h
@@ -352,6 +352,32 @@ typedef tai_status_t (*tai_get_module_attributes_fn)(
         _Inout_ tai_attribute_t *attr_list);
 
 /**
+ * @brief Get module capability
+ *
+ * @param[in] module_id Module id
+ * @param[inout] cap Attribute capability
+ *
+ * @return #TAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef tai_status_t (*tai_get_module_capability_fn)(
+        _In_ tai_object_id_t module_id,
+        _Inout_ tai_attribute_capability_t *cap);
+
+/**
+ * @brief Get multiple module capabilities
+ *
+ * @param[in] module_id Module id
+ * @param[in] count Number of capabilities
+ * @param[inout] list Attribute capabilities
+ *
+ * @return #TAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef tai_status_t (*tai_get_module_capabilities_fn)(
+        _In_ tai_object_id_t module_id,
+        _In_ uint32_t count,
+        _Inout_ tai_attribute_capability_t *list);
+
+/**
  * @brief Module method table retrieved with tai_api_query()
  */
 typedef struct _tai_module_api_t
@@ -362,6 +388,8 @@ typedef struct _tai_module_api_t
     tai_set_module_attributes_fn    set_module_attributes;
     tai_get_module_attribute_fn     get_module_attribute;
     tai_get_module_attributes_fn    get_module_attributes;
+    tai_get_module_capability_fn    get_module_capability;
+    tai_get_module_capabilities_fn  get_module_capabilities;
 
 } tai_module_api_t;
 

--- a/inc/tainetworkif.h
+++ b/inc/tainetworkif.h
@@ -640,16 +640,44 @@ typedef tai_status_t (*tai_get_network_interface_attributes_fn)(
         _Inout_ tai_attribute_t *attr_list);
 
 /**
+ * @brief Get network interface capability
+ *
+ * @param[in] network_interface_id Network interface id
+ * @param[inout] attr Attribute capability
+ *
+ * @return #TAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef tai_status_t (*tai_get_network_interface_capability_fn)(
+        _In_ tai_object_id_t network_interface_id,
+        _Inout_ tai_attribute_capability_t *cap);
+
+/**
+ * @brief Get multiple network interface capabilities
+ *
+ * @param[in] network_interface_id Network Interface id
+ * @param[in] count Number of capabilities
+ * @param[inout] list Attribute capabilities
+ *
+ * @return #TAI_STATUS_SUCCESS on success, failure status code on error
+ */
+typedef tai_status_t (*tai_get_network_interface_capabilities_fn)(
+        _In_ tai_object_id_t network_interface_id,
+        _In_ uint32_t count,
+        _Inout_ tai_attribute_capability_t *list);
+
+/**
  * @brief Routing interface methods table retrieved with tai_api_query()
  */
 typedef struct _tai_network_interface_api_t
 {
-    tai_create_network_interface_fn          create_network_interface;
-    tai_remove_network_interface_fn          remove_network_interface;
-    tai_set_network_interface_attribute_fn   set_network_interface_attribute;
-    tai_set_network_interface_attributes_fn  set_network_interface_attributes;
-    tai_get_network_interface_attribute_fn   get_network_interface_attribute;
-    tai_get_network_interface_attributes_fn  get_network_interface_attributes;
+    tai_create_network_interface_fn             create_network_interface;
+    tai_remove_network_interface_fn             remove_network_interface;
+    tai_set_network_interface_attribute_fn      set_network_interface_attribute;
+    tai_set_network_interface_attributes_fn     set_network_interface_attributes;
+    tai_get_network_interface_attribute_fn      get_network_interface_attribute;
+    tai_get_network_interface_attributes_fn     get_network_interface_attributes;
+    tai_get_network_interface_capability_fn     get_network_interface_capability;
+    tai_get_network_interface_capabilities_fn   get_network_interface_capabilities;
 
 } tai_network_interface_api_t;
 

--- a/inc/taitypes.h
+++ b/inc/taitypes.h
@@ -294,6 +294,32 @@ typedef struct _tai_attribute_t
     tai_attribute_value_t value;
 } tai_attribute_t;
 
+typedef struct _tai_attribute_capability_t {
+    tai_attr_id_t         id;
+
+    /* default value is set by TAI adapter */
+    bool                  valid_defaultvalue;
+    /* min is set by TAI adapter */
+    bool                  valid_min;
+    /* max is set by TAI adapter */
+    bool                  valid_max;
+    /* supportedvalues is set by TAI adapter */
+    bool                  valid_supportedvalues;
+
+    /* default value of this attribute */
+    tai_attribute_value_t defaultvalue;
+
+    /* minimum value of this attribute */
+    tai_attribute_value_t min;
+
+    /* maximum value of this attribute */
+    tai_attribute_value_t max;
+
+    /* supported values of this attribute ( only valid for enum attribute ) */
+    tai_attr_value_list_t supportedvalues;
+
+} tai_attribute_capability_t;
+
 /**
  * @}
  */

--- a/meta/taimetadatautils.c
+++ b/meta/taimetadatautils.c
@@ -348,6 +348,14 @@ bool tai_metadata_is_condition_met(
     *result = ( lhs->value.valuename == rhs->value.valuename );\
     break;
 
+#define _TAI_META_LE(result, valuename)                       \
+    *result = ( lhs->value.valuename <= rhs->value.valuename );\
+    break;
+
+#define _TAI_META_GE(result, valuename)                       \
+    *result = ( lhs->value.valuename >= rhs->value.valuename );\
+    break;
+
 #define _TAI_META_CMP_LIST(result, valuename)                                 \
     {                                                                         \
     if( lhs->value.valuename.count != rhs->value.valuename.count ) {          \
@@ -562,7 +570,6 @@ static int _tai_list_size(
         return -1;
     }
 }
-
 
 static tai_status_t _tai_metadata_alloc_attr_value(
         _In_ const tai_attr_metadata_t* const metadata,
@@ -812,6 +819,74 @@ tai_status_t tai_metadata_deepcopy_attr_value(
     }
     out->id = in->id;
     return _tai_metadata_deepcopy_attr_value(metadata, &in->value, &out->value);
+}
+
+// if lhs <= rhs then result=1, else result=0
+tai_status_t tai_metadata_le_attr_value(
+        _In_ const tai_attr_metadata_t* const metadata,
+        _In_ const tai_attribute_t* const lhs,
+        _In_ const tai_attribute_t* const rhs,
+        _Out_ bool* result) {
+    if ( metadata == NULL || result == NULL || lhs == NULL || rhs == NULL || lhs->id != rhs->id ) {
+        return TAI_STATUS_INVALID_PARAMETER;
+    }
+    switch ( metadata->attrvaluetype ) {
+    case TAI_ATTR_VALUE_TYPE_U8:
+        _TAI_META_LE(result, u8)
+    case TAI_ATTR_VALUE_TYPE_S8:
+        _TAI_META_LE(result, s8)
+    case TAI_ATTR_VALUE_TYPE_U16:
+        _TAI_META_LE(result, u16)
+    case TAI_ATTR_VALUE_TYPE_S16:
+        _TAI_META_LE(result, s16)
+    case TAI_ATTR_VALUE_TYPE_U32:
+        _TAI_META_LE(result, u32)
+    case TAI_ATTR_VALUE_TYPE_S32:
+        _TAI_META_LE(result, s32)
+    case TAI_ATTR_VALUE_TYPE_U64:
+        _TAI_META_LE(result, u64)
+    case TAI_ATTR_VALUE_TYPE_S64:
+        _TAI_META_LE(result, s64)
+    case TAI_ATTR_VALUE_TYPE_FLT:
+        _TAI_META_LE(result, flt)
+    default:
+        return TAI_STATUS_NOT_SUPPORTED;
+    }
+    return TAI_STATUS_SUCCESS;
+}
+
+// if lhs => rhs then result=1, else result=0 
+tai_status_t tai_metadata_ge_attr_value(
+        _In_ const tai_attr_metadata_t* const metadata,
+        _In_ const tai_attribute_t* const lhs,
+        _In_ const tai_attribute_t* const rhs,
+        _Out_ bool* result) {
+    if ( metadata == NULL || result == NULL || lhs == NULL || rhs == NULL || lhs->id != rhs->id ) {
+        return TAI_STATUS_INVALID_PARAMETER;
+    }
+    switch ( metadata->attrvaluetype ) {
+    case TAI_ATTR_VALUE_TYPE_U8:
+        _TAI_META_GE(result, u8)
+    case TAI_ATTR_VALUE_TYPE_S8:
+        _TAI_META_GE(result, s8)
+    case TAI_ATTR_VALUE_TYPE_U16:
+        _TAI_META_GE(result, u16)
+    case TAI_ATTR_VALUE_TYPE_S16:
+        _TAI_META_GE(result, s16)
+    case TAI_ATTR_VALUE_TYPE_U32:
+        _TAI_META_GE(result, u32)
+    case TAI_ATTR_VALUE_TYPE_S32:
+        _TAI_META_GE(result, s32)
+    case TAI_ATTR_VALUE_TYPE_U64:
+        _TAI_META_GE(result, u64)
+    case TAI_ATTR_VALUE_TYPE_S64:
+        _TAI_META_GE(result, s64)
+    case TAI_ATTR_VALUE_TYPE_FLT:
+        _TAI_META_GE(result, flt)
+    default:
+        return TAI_STATUS_NOT_SUPPORTED;
+    }
+    return TAI_STATUS_SUCCESS;
 }
 
 tai_status_t tai_metadata_deepequal_attr_value(

--- a/meta/taimetadatautils.h
+++ b/meta/taimetadatautils.h
@@ -239,6 +239,18 @@ extern tai_status_t tai_metadata_deepequal_attr_value(
         _In_ const tai_attribute_t* const rhs,
         _Out_ bool* result);
 
+extern tai_status_t tai_metadata_le_attr_value(
+        _In_ const tai_attr_metadata_t* const metadata,
+        _In_ const tai_attribute_t* const lhs,
+        _In_ const tai_attribute_t* const rhs,
+        _Out_ bool* result);
+
+extern tai_status_t tai_metadata_ge_attr_value(
+        _In_ const tai_attr_metadata_t* const metadata,
+        _In_ const tai_attribute_t* const lhs,
+        _In_ const tai_attribute_t* const rhs,
+        _Out_ bool* result);
+
 /**
  * @}
  */

--- a/tools/framework/config.hpp
+++ b/tools/framework/config.hpp
@@ -217,6 +217,10 @@ namespace tai::framework {
             }
 
             tai_status_t set_attributes(uint32_t attr_count, const tai_attribute_t * const attr_list, FSMState& next_state, bool readonly = false) {
+                if ( attr_count == 0 ) {
+                    return TAI_STATUS_SUCCESS;
+                }
+
                 std::vector<const tai_attribute_t*> diff;
                 {
                     std::unique_lock<std::mutex> lk(m_mtx);

--- a/tools/framework/config.hpp
+++ b/tools/framework/config.hpp
@@ -122,14 +122,6 @@ namespace tai::framework {
                 }
             }
 
-            std::vector<tai_attribute_t> list() const {
-                std::unique_lock<std::mutex> lk(m_mtx);
-                std::vector<tai_attribute_t> list;
-                std::transform(m_config.begin(), m_config.end(), list.begin(),
-                    [](std::pair<const tai_attr_id_t, S_Attribute>& p) { return p.second->raw(); });
-                return list;
-            }
-
             const tai_attribute_value_t* get(tai_attr_id_t id, bool no_default = false) const {
                 std::unique_lock<std::mutex> lk(m_mtx);
                 return _get(id, no_default);

--- a/tools/framework/config.hpp
+++ b/tools/framework/config.hpp
@@ -12,6 +12,7 @@
 #include <mutex>
 
 #include "attribute.hpp"
+#include "capability.hpp"
 #include "fsm.hpp"
 #include "logger.hpp"
 
@@ -37,10 +38,15 @@ namespace tai::framework {
     // user : context
     using setter_f = std::function< tai_status_t(const tai_attribute_t* const attribute, FSMState* fsm, void* const user) >;
 
-    // getter_f : the callback function which gets called when setting the attribute
+    // getter_f : the callback function which gets called when getting the attribute
     // attribute : the attribute to be get
     // user : context
     using getter_f = std::function< tai_status_t(tai_attribute_t* const attribute, void* const user) >;
+
+    // cap_getter_f : the callback function which gets called when getting the attribute capability
+    // capability: the attribute capability to be get
+    // user : context
+    using cap_getter_f = std::function< tai_status_t(tai_attribute_capability_t* const capability, void* const user) >;
 
     class EnumValidator {
         public:
@@ -57,15 +63,58 @@ namespace tai::framework {
 
     template<tai_object_type_t T>
     struct AttributeInfo {
-        AttributeInfo(int32_t id) : id(id), defaultvalue(nullptr), fsm(FSM_STATE_INIT), meta(tai_metadata_get_attr_metadata(T, id)), no_store(false), setter(nullptr), getter(nullptr), validator(nullptr) {}
-        AttributeInfo(int32_t id, FSMState fsm, const tai_attribute_value_t* const value, validator_f validator, setter_f setter, getter_f getter, bool no_store) : id(id), defaultvalue(value), fsm(fsm), meta(tai_metadata_get_attr_metadata(T, id)), no_store(no_store), setter(setter), getter(getter), validator(validator) {}
+        AttributeInfo(int32_t id) : id(id), defaultvalue(nullptr), min(nullptr), max(nullptr), fsm(FSM_STATE_INIT), meta(tai_metadata_get_attr_metadata(T, id)), no_store(false), setter(nullptr), getter(nullptr), validator(nullptr), cap_getter(nullptr) {}
+        AttributeInfo(int32_t id,
+                FSMState fsm,
+                const tai_attribute_value_t* const defaultvalue,
+                const tai_attribute_value_t* const min,
+                const tai_attribute_value_t* const max,
+                std::set<int32_t> valid_enums,
+                validator_f validator,
+                setter_f setter,
+                getter_f getter,
+                bool no_store,
+                cap_getter_f cap_getter) : id(id), defaultvalue(defaultvalue), min(min), max(max), valid_enums(valid_enums), fsm(fsm), meta(tai_metadata_get_attr_metadata(T, id)), no_store(no_store), setter(setter), getter(getter), validator(validator), cap_getter(cap_getter) {}
 
-        AttributeInfo set_fsm_state(FSMState v)                         { return AttributeInfo(id, v, defaultvalue, validator, setter, getter, no_store); }
-        AttributeInfo set_default(const tai_attribute_value_t* const v) { return AttributeInfo(id, fsm, v, validator, setter, getter, no_store); }
-        AttributeInfo set_validator(validator_f v)                      { return AttributeInfo(id, fsm, defaultvalue, v, setter, getter, no_store); }
-        AttributeInfo set_setter(setter_f v)                            { return AttributeInfo(id, fsm, defaultvalue, validator, v, getter, no_store); }
-        AttributeInfo set_getter(getter_f v)                            { return AttributeInfo(id, fsm, defaultvalue, validator, setter, v, no_store); }
-        AttributeInfo set_no_store(bool v)                              { return AttributeInfo(id, fsm, defaultvalue, validator, setter, getter, v); }
+        AttributeInfo set_fsm_state(FSMState fsm) { 
+            return AttributeInfo(id, fsm, defaultvalue, min, max, valid_enums, validator, setter, getter, no_store, cap_getter);
+        }
+
+        AttributeInfo set_default(const tai_attribute_value_t* const defaultvalue) {
+            return AttributeInfo(id, fsm, defaultvalue, min, max, valid_enums, validator, setter, getter, no_store, cap_getter);
+        }
+
+        AttributeInfo set_min(const tai_attribute_value_t* const min) {
+            return AttributeInfo(id, fsm, defaultvalue, min, max, valid_enums, validator, setter, getter, no_store, cap_getter);
+        }
+
+        AttributeInfo set_max(const tai_attribute_value_t* const max) {
+            return AttributeInfo(id, fsm, defaultvalue, min, max, valid_enums, validator, setter, getter, no_store, cap_getter);
+        }
+
+        AttributeInfo set_valid_enums(std::set<int32_t> valid_enums) {
+            return AttributeInfo(id, fsm, defaultvalue, min, max, valid_enums, validator, setter, getter, no_store, cap_getter);
+        }
+
+        AttributeInfo set_validator(validator_f validator) {
+            return AttributeInfo(id, fsm, defaultvalue, min, max, valid_enums, validator, setter, getter, no_store, cap_getter);
+        }
+
+        AttributeInfo set_setter(setter_f setter) {
+            return AttributeInfo(id, fsm, defaultvalue, min, max, valid_enums, validator, setter, getter, no_store, cap_getter);
+        }
+
+        AttributeInfo set_getter(getter_f getter) {
+            return AttributeInfo(id, fsm, defaultvalue, min, max, valid_enums, validator, setter, getter, no_store, cap_getter);
+        }
+
+        AttributeInfo set_no_store(bool no_store) {
+            return AttributeInfo(id, fsm, defaultvalue, min, max, valid_enums, validator, setter, getter, no_store, cap_getter);
+        }
+
+        AttributeInfo set_cap_getter(cap_getter_f cap_getter) {
+            return AttributeInfo(id, fsm, defaultvalue, min, max, valid_enums, validator, setter, getter, no_store, cap_getter);
+        }
 
         int id;
         const tai_attr_metadata_t* const meta;
@@ -75,10 +124,15 @@ namespace tai::framework {
 
         // overrides the default value specified in TAI headers by @default
         const tai_attribute_value_t* const defaultvalue;
+        const tai_attribute_value_t* const min;
+        const tai_attribute_value_t* const max;
+        std::set<int32_t> valid_enums;
+
         validator_f validator;
         setter_f setter;
         getter_f getter;
         bool no_store; // only execute the set_hook and don't store the attribute to the config
+        cap_getter_f cap_getter;
     };
 
     template<tai_object_type_t T>
@@ -111,10 +165,17 @@ namespace tai::framework {
     // error_info : list of the error status in previous set path
     using default_getter_f = std::function< tai_status_t(uint32_t count, tai_attribute_t* const attrs, void* const user, const error_info* const) >;
 
+    // default_cap_getter_f : the fallback callback function which gets called when any error happens in capability get path
+    // count : number of capabilities
+    // attrs : list of the capability to be get
+    // user : context
+    // error_info : list of the error status in previous set path
+    using default_cap_getter_f = std::function< tai_status_t(uint32_t count, tai_attribute_capability_t* const caps, void* const user, const error_info* const) >;
+
     template<tai_object_type_t T>
     class Config {
         public:
-            Config(uint32_t attr_count = 0, const tai_attribute_t* attr_list = nullptr, void* user = nullptr, default_setter_f setter = nullptr, default_getter_f getter = nullptr) : m_user(user), m_default_setter(setter), m_default_getter(getter) {
+            Config(uint32_t attr_count = 0, const tai_attribute_t* attr_list = nullptr, void* user = nullptr, default_setter_f setter = nullptr, default_getter_f getter = nullptr, default_cap_getter_f cap_getter = nullptr) : m_user(user), m_default_setter(setter), m_default_getter(getter), m_default_cap_getter(cap_getter) {
                 FSMState tmp;
                 auto ret = set_attributes(attr_count, attr_list, tmp, true);
                 if ( ret != TAI_STATUS_SUCCESS ) {
@@ -155,6 +216,42 @@ namespace tai::framework {
 
             tai_status_t set_readonly(const tai_attribute_t& src, bool without_hook = false) {
                 return _set(src, true, without_hook);
+            }
+
+            tai_status_t get_capabilities(uint32_t count, tai_attribute_capability_t * const list) {
+                std::vector<std::pair<tai_attribute_capability_t * const, error_info>> failed_caps;
+                for ( auto i = 0; i < count; i++ ) {
+                    auto cap = &list[i];
+                    std::unique_lock<std::mutex> lk(m_mtx);
+                    tai_attribute_capability_t capability;
+                    auto status = _get_capability(cap);
+                    if ( status != TAI_STATUS_SUCCESS ) {
+                        status = convert_tai_error_to_list(status, i);
+                        if ( m_default_cap_getter == nullptr ) {
+                            return status;
+                        }
+                        failed_caps.emplace_back(std::make_pair(cap, error_info{i, status}));
+                        continue;
+                    }
+                }
+
+                if ( m_default_cap_getter != nullptr && failed_caps.size() > 0 ) {
+                    std::vector<tai_attribute_capability_t> l;
+                    std::vector<error_info> err_list;
+                    for ( auto& a : failed_caps ) {
+                        l.emplace_back(*a.first);
+                        err_list.emplace_back(a.second);
+                    }
+                    auto ret = m_default_cap_getter(l.size(), l.data(), m_user, err_list.data());
+                    for ( auto i = 0; i < l.size(); i++ ) {
+                        const auto& a = failed_caps[i];
+                        list[a.second.index] = l[i];
+                    }
+                    if ( ret != TAI_STATUS_SUCCESS ) {
+                        return ret;
+                    }
+                }
+                return TAI_STATUS_SUCCESS;
             }
 
             tai_status_t get_attributes(uint32_t attr_count, tai_attribute_t * const attr_list) {
@@ -230,8 +327,8 @@ namespace tai::framework {
                         if ( m_default_setter == nullptr && info == m_info.end() ) {
                             return convert_tai_error_to_list(TAI_STATUS_ATTR_NOT_SUPPORTED_0, i);
                         }
-                        if ( info != m_info.end() && info->second.validator != nullptr ) {
-                            auto ret = info->second.validator(&attr.value);
+                        if ( info != m_info.end() ) {
+                            auto ret = _validate(attr);
                             if ( ret != TAI_STATUS_SUCCESS ) {
                                 return convert_tai_error_to_list(ret, i);
                             }
@@ -326,6 +423,14 @@ namespace tai::framework {
                 return m_config.size();
             }
 
+            AttributeInfo<T> const * const info(tai_attr_id_t id) {
+                auto iter = m_info.find(id);
+                if ( iter == m_info.end() ) {
+                    return nullptr;
+                }
+                return &iter->second;
+            }
+
             tai_status_t direct_set(S_Attribute src) {
                 return _set(src, false, false, nullptr, true);
             }
@@ -335,6 +440,52 @@ namespace tai::framework {
             }
 
         private:
+            tai_status_t _get_capability(tai_attribute_capability_t* cap) const {
+                if ( cap == nullptr ) {
+                    return TAI_STATUS_INVALID_PARAMETER;
+                }
+                auto info = m_info.find(cap->id);
+                if ( info == m_info.end() ) {
+                    return TAI_STATUS_ATTR_NOT_SUPPORTED_0;
+                }
+
+                if ( info->second.min != nullptr ) {
+                    cap->min = *info->second.min;
+                    cap->valid_min = true;
+                }
+
+                if ( info->second.max != nullptr ) {
+                    cap->max = *info->second.max;
+                    cap->valid_max = true;
+                }
+
+                if ( info->second.defaultvalue != nullptr ) {
+                    cap->defaultvalue = *info->second.defaultvalue;
+                    cap->valid_defaultvalue = true;
+                } else if ( info->second.meta->defaultvalue != nullptr ) {
+                    cap->defaultvalue = *info->second.meta->defaultvalue;
+                    cap->valid_defaultvalue = true;
+                }
+
+                if ( info->second.valid_enums.size() > 0 ) {
+                    auto& enums = info->second.valid_enums;
+                    if ( cap->supportedvalues.count < enums.size() ) {
+                        cap->supportedvalues.count = enums.size();
+                        return TAI_STATUS_BUFFER_OVERFLOW;
+                    }
+                    cap->supportedvalues.count = enums.size();
+                    int i = 0;
+                    for ( auto e : enums ) {
+                        cap->supportedvalues.list[i++].s32 = e;
+                    }
+                    cap->valid_supportedvalues = true;
+                }
+
+                if ( info->second.cap_getter != nullptr ) {
+                    return info->second.cap_getter(cap, m_user);
+                }
+                return TAI_STATUS_SUCCESS;
+            }
 
             const tai_attribute_value_t* _get(tai_attr_id_t id, bool no_default = false, bool direct = false) const {
                 auto info = m_info.find(id);
@@ -396,10 +547,98 @@ namespace tai::framework {
                 return _set(attr, readonly, without_hook, fsm);
             }
 
+            tai_status_t _validate(const tai_attribute_t& attr) {
+                auto info = m_info.find(attr.id);
+                if ( info == m_info.end() ) {
+                    TAI_DEBUG("no meta: 0x%x", attr.id);
+                    return TAI_STATUS_ATTR_NOT_SUPPORTED_0;
+                }
+
+                auto cmp = [&](const tai_attribute_t& lhs, const tai_attribute_t& rhs) -> tai_status_t {
+                   bool result;
+                    auto ret = tai_metadata_le_attr_value(info->second.meta, &lhs, &rhs, &result);
+                    if ( ret != TAI_STATUS_SUCCESS ) {
+                        return ret;
+                    }
+                    if ( !result ) {
+                        return TAI_STATUS_INVALID_ATTR_VALUE_0;
+                    }
+                    return TAI_STATUS_SUCCESS;
+                };
+
+                if ( info->second.min != nullptr ) {
+                    tai_attribute_t min = {.id = attr.id, .value = *info->second.min};
+                    auto ret = cmp(min, attr);
+                    if ( ret != TAI_STATUS_SUCCESS ) {
+                        return ret;
+                    }
+                }
+
+                if ( info->second.max != nullptr ) {
+                    tai_attribute_t max = {.id = attr.id, .value = *info->second.max};
+                    auto ret = cmp(attr, max);
+                    if ( ret != TAI_STATUS_SUCCESS ) {
+                        return ret;
+                    }
+                }
+
+                auto& valids = info->second.valid_enums;
+                if ( valids.size() > 0 ) {
+                    if ( valids.find(attr.value.s32) == valids.end() ) {
+                        return TAI_STATUS_INVALID_ATTR_VALUE_0;
+                    }
+                }
+
+                if ( info->second.validator != nullptr ) {
+                    return info->second.validator(&attr.value);
+                }
+
+                if ( info->second.cap_getter != nullptr ) {
+                    try {
+                        auto v = std::make_unique<tai::Capability>(info->second.meta, [&](tai_attribute_capability_t* c) -> tai_status_t {
+                            return info->second.cap_getter(c, m_user);
+                        });
+                        auto cap = v->raw();
+                        if ( cap->valid_min ) {
+                            tai_attribute_t min = {.id = attr.id, .value = cap->min};
+                            auto ret = cmp(min, attr);
+                            if ( ret != TAI_STATUS_SUCCESS ) {
+                                return ret;
+                            }
+                        }
+                        if ( cap->valid_max ) {
+                            tai_attribute_t max = {.id = attr.id, .value = cap->max};
+                            auto ret = cmp(attr, max);
+                            if ( ret != TAI_STATUS_SUCCESS ) {
+                                return ret;
+                            }
+                        }
+                        if ( cap->valid_supportedvalues ) {
+                            auto valids = cap->supportedvalues;
+                            bool found = false;
+                            for ( int i = 0; i < valids.count; i++ ) {
+                                if ( valids.list[i].s32 == attr.value.s32 ) {
+                                    found = true;
+                                    break;
+                                }
+                            }
+                            if (!found) {
+                                return TAI_STATUS_INVALID_ATTR_VALUE_0;
+                            }
+                        }
+
+                    } catch (tai::Exception& e) {
+                        return e.err();
+                    }
+                }
+                return TAI_STATUS_SUCCESS;
+            }
+
             static const AttributeInfoMap<T> m_info;
             std::map<tai_attr_id_t, S_Attribute> m_config;
             const default_setter_f m_default_setter;
             const default_getter_f m_default_getter;
+            const default_cap_getter_f m_default_cap_getter;
             mutable std::mutex m_mtx;
             void* const m_user;
     };

--- a/tools/framework/examples/basic/basic.cpp
+++ b/tools/framework/examples/basic/basic.cpp
@@ -412,13 +412,13 @@ namespace tai::basic {
             select(FD_SETSIZE, &fs, NULL, NULL, NULL);
             if (FD_ISSET(evfd, &fs)) {
                 uint64_t r;
-                read(evfd, &r, sizeof(uint64_t));
+                r = read(evfd, &r, sizeof(uint64_t));
                 next = next_state();
                 goto ret;
             }
             if (FD_ISSET(tfd, &fs)) {
                 uint64_t r;
-                read(tfd, &r, sizeof(uint64_t));
+                r = read(tfd, &r, sizeof(uint64_t));
                 if ( configured() && !m_no_transit ) {
                     return FSM_STATE_READY;
                 }
@@ -455,13 +455,13 @@ namespace tai::basic {
             select(FD_SETSIZE, &fs, NULL, NULL, NULL);
             if (FD_ISSET(evfd, &fs)) {
                 uint64_t r;
-                read(evfd, &r, sizeof(uint64_t));
+                r = read(evfd, &r, sizeof(uint64_t));
                 next = next_state();
                 goto ret;
             }
             if (FD_ISSET(tfd, &fs)) {
                 uint64_t r;
-                read(tfd, &r, sizeof(uint64_t));
+                r = read(tfd, &r, sizeof(uint64_t));
                 // implementation of notification
                 if ( m_module != nullptr ) {
                     m_module->notify(TAI_MODULE_ATTR_NOTIFY, {

--- a/tools/framework/examples/basic/basic.hpp
+++ b/tools/framework/examples/basic/basic.hpp
@@ -113,7 +113,8 @@ namespace tai::basic {
         public:
             Object(uint32_t count, const tai_attribute_t *list, S_FSM fsm) : tai::framework::Object<T>(count, list, fsm, reinterpret_cast<void*>(fsm.get()),
                     std::bind(&Object::default_setter, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5),
-                    std::bind(&Object::default_getter, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4)) {}
+                    std::bind(&Object::default_getter, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4),
+                    std::bind(&Object::default_cap_getter, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4)) {}
 
             tai_object_id_t id() const {
                 return m_id;
@@ -160,6 +161,20 @@ namespace tai::basic {
                         }
                     } else {
                         return TAI_STATUS_UNINITIALIZED;
+                    }
+                }
+                return TAI_STATUS_SUCCESS;
+            }
+
+            tai_status_t default_cap_getter(uint32_t count, tai_attribute_capability_t* const caps, void* const user, const tai::framework::error_info* const info) {
+                for ( auto i = 0; i< count; i++ ) {
+                    auto cap = &caps[i];
+                    auto meta = tai_metadata_get_attr_metadata(T, cap->id);
+                    if ( meta == nullptr ) {
+                        return convert_tai_error_to_list(TAI_STATUS_ATTR_NOT_SUPPORTED_0, info[i].index);
+                    }
+                    if ( meta->defaultvalue != nullptr ) {
+                        cap->defaultvalue = *meta->defaultvalue;
                     }
                 }
                 return TAI_STATUS_SUCCESS;

--- a/tools/framework/tai.cpp
+++ b/tools/framework/tai.cpp
@@ -140,6 +140,22 @@ static tai_status_t clear_host_interface_attribute(_In_ tai_object_id_t id, _In_
     return clear_host_interface_attributes(id, 1, &attr_id);
 }
 
+static tai_status_t get_host_interface_capabilities(tai_object_id_t oid, uint32_t count, tai_attribute_capability_t *list) {
+    if ( g_platform == nullptr ) {
+        return TAI_STATUS_UNINITIALIZED;
+    }
+    auto obj = g_platform->get(oid, TAI_OBJECT_TYPE_HOSTIF);
+    if ( obj == nullptr ) {
+        return TAI_STATUS_ITEM_NOT_FOUND;
+    }
+    return obj->get_capabilities(count, list);
+}
+
+
+static tai_status_t get_host_interface_capability(tai_object_id_t oid, tai_attribute_capability_t *cap) {
+    return get_host_interface_capabilities(oid, 1, cap);
+}
+
 /**
  * @brief The host interface functions. This structure is retrieved via the 
  *        #tai_api_query function.
@@ -152,7 +168,9 @@ static tai_host_interface_api_t host_interface_api = {
     .get_host_interface_attribute    = get_host_interface_attribute,
     .get_host_interface_attributes   = get_host_interface_attributes,
     .clear_host_interface_attribute  = clear_host_interface_attribute,
-    .clear_host_interface_attributes = clear_host_interface_attributes
+    .clear_host_interface_attributes = clear_host_interface_attributes,
+    .get_host_interface_capability   = get_host_interface_capability,
+    .get_host_interface_capabilities = get_host_interface_capabilities
 };
 
 /**
@@ -234,6 +252,21 @@ static tai_status_t set_network_interface_attribute(
     return set_network_interface_attributes(id, 1, attr);
 }
 
+static tai_status_t get_network_interface_capabilities(tai_object_id_t oid, uint32_t count, tai_attribute_capability_t *list) {
+    if ( g_platform == nullptr ) {
+        return TAI_STATUS_UNINITIALIZED;
+    }
+    auto obj = g_platform->get(oid, TAI_OBJECT_TYPE_NETWORKIF);
+    if ( obj == nullptr ) {
+        return TAI_STATUS_ITEM_NOT_FOUND;
+    }
+    return obj->get_capabilities(count, list);
+}
+
+
+static tai_status_t get_network_interface_capability(tai_object_id_t oid, tai_attribute_capability_t *cap) {
+    return get_network_interface_capabilities(oid, 1, cap);
+}
 
 /**
  * @brief Network interface initialization. After the call the capability 
@@ -282,12 +315,14 @@ static tai_status_t remove_network_interface(_In_ tai_object_id_t network_interf
  *        #tai_api_query function.
  */
 static tai_network_interface_api_t network_interface_api = {
-    .create_network_interface         = create_network_interface,
-    .remove_network_interface         = remove_network_interface,
-    .set_network_interface_attribute  = set_network_interface_attribute,
-    .set_network_interface_attributes = set_network_interface_attributes,
-    .get_network_interface_attribute  = get_network_interface_attribute,
-    .get_network_interface_attributes = get_network_interface_attributes
+    .create_network_interface           = create_network_interface,
+    .remove_network_interface           = remove_network_interface,
+    .set_network_interface_attribute    = set_network_interface_attribute,
+    .set_network_interface_attributes   = set_network_interface_attributes,
+    .get_network_interface_attribute    = get_network_interface_attribute,
+    .get_network_interface_attributes   = get_network_interface_attributes,
+    .get_network_interface_capability   = get_network_interface_capability,
+    .get_network_interface_capabilities = get_network_interface_capabilities
 };
 
 tai_status_t remove_module(tai_object_id_t module_id) {
@@ -327,6 +362,22 @@ tai_status_t get_module_attribute(tai_object_id_t module_id, tai_attribute_t *at
     return get_module_attributes(module_id, 1, attr_list);
 }
 
+
+tai_status_t get_module_capabilities(tai_object_id_t oid, uint32_t count, tai_attribute_capability_t *list) {
+    if ( g_platform == nullptr ) {
+        return TAI_STATUS_UNINITIALIZED;
+    }
+    auto obj = g_platform->get(oid, TAI_OBJECT_TYPE_MODULE);
+    if ( obj == nullptr ) {
+        return TAI_STATUS_ITEM_NOT_FOUND;
+    }
+    return obj->get_capabilities(count, list);
+}
+
+tai_status_t get_module_capability(tai_object_id_t oid, tai_attribute_capability_t *cap) {
+    return get_module_capabilities(oid, 1, cap);
+}
+
 static tai_status_t create_module(tai_object_id_t *module_id, uint32_t attr_count, const tai_attribute_t *attr_list) {
     if ( g_platform == nullptr ) {
         return TAI_STATUS_UNINITIALIZED;
@@ -341,6 +392,8 @@ static tai_module_api_t module_api = {
     .set_module_attributes = set_module_attributes,
     .get_module_attribute =  get_module_attribute,
     .get_module_attributes = get_module_attributes,
+    .get_module_capability = get_module_capability,
+    .get_module_capabilities = get_module_capabilities
 };
 
 static tai_status_t list_metadata(const tai_metadata_key_t *const key, uint32_t *count, const tai_attr_metadata_t * const **list) {

--- a/tools/lib/capability.hpp
+++ b/tools/lib/capability.hpp
@@ -1,0 +1,70 @@
+#ifndef __CAPABILITY_HPP__
+#define __CAPABILITY_HPP__
+
+#include "attribute.hpp"
+#include <memory>
+
+namespace tai {
+
+    class Capability;
+
+    using S_Capability = std::shared_ptr<Capability>;
+
+    using cap_getter = std::function<tai_status_t(tai_attribute_capability_t*)>;
+
+    class Capability {
+        public:
+            Capability(const tai_attr_metadata_t* const meta, cap_getter getter) :  m_meta(meta), m_cap() {
+                if ( meta == nullptr ) {
+                    throw Exception(TAI_STATUS_INVALID_PARAMETER);
+                }
+                if ( meta->isenum && meta->enummetadata != nullptr ) {
+                    tai_attr_metadata_t m = {
+                        .attrvaluetype = TAI_ATTR_VALUE_TYPE_ATTRLIST,
+                        .attrlistvaluetype = TAI_ATTR_VALUE_TYPE_S32
+                    };
+                    tai_alloc_info_t alloc_info = {
+                        .list_size = static_cast<uint32_t>(meta->enummetadata->valuescount)
+                    };
+                    tai_attribute_t a = {};
+                    auto ret = tai_metadata_alloc_attr_value(&m, &a, &alloc_info);
+                    if ( ret != TAI_STATUS_SUCCESS ) {
+                        throw Exception(ret);
+                    }
+                    m_cap.supportedvalues = a.value.attrlist;
+                }
+                m_cap.id = meta->attrid;
+                auto ret = getter(&m_cap);
+                if ( ret != TAI_STATUS_SUCCESS ) {
+                    _free();
+                    throw Exception(ret);
+                }
+            }
+
+            const tai_attribute_capability_t* const raw(){
+                return &m_cap;
+            }
+
+            ~Capability(){
+                _free();
+            }
+
+        private:
+            const tai_attr_metadata_t* const m_meta;
+            tai_attribute_capability_t m_cap;
+
+            tai_status_t _free() {
+                if ( !m_meta->isenum || m_meta->enummetadata == nullptr ) {
+                    return TAI_STATUS_SUCCESS;
+                }
+                tai_attr_metadata_t m{
+                    .attrvaluetype = TAI_ATTR_VALUE_TYPE_ATTRLIST,
+                    .attrlistvaluetype = TAI_ATTR_VALUE_TYPE_S32
+                };
+                tai_attribute_t a{.value = {.attrlist = m_cap.supportedvalues}};
+                return tai_metadata_free_attr_value(&m, &a, nullptr);
+            }
+    };
+}
+
+#endif // __CAPABILITY_HPP__

--- a/tools/taish/client/taish/main.py
+++ b/tools/taish/client/taish/main.py
@@ -68,6 +68,15 @@ class TAIShellObject(Object):
             except TAIException as e:
                 print('err: {} (code: {:x})'.format(e.msg, e.code))
 
+        @self.command(TAICompleter(m, set_=False))
+        def capability(args):
+            if len(args) != 1:
+                raise InvalidInput('usage: capability <name>')
+            try:
+                print(self.client.get_attribute_capability(args[0]))
+            except TAIException as e:
+                print('err: {} (code {:x})'.format(e.msg, e.code))
+
         @self.command()
         def monitor(args):
             if len(args) == 0:

--- a/tools/taish/include/taigrpc.hpp
+++ b/tools/taish/include/taigrpc.hpp
@@ -105,6 +105,7 @@ class TAIServiceImpl final : public taish::TAI::Service {
         ::grpc::Status ListModule(::grpc::ServerContext* context, const taish::ListModuleRequest* request, ::grpc::ServerWriter< taish::ListModuleResponse>* writer);
         ::grpc::Status ListAttributeMetadata(::grpc::ServerContext* context, const taish::ListAttributeMetadataRequest* request, ::grpc::ServerWriter< taish::ListAttributeMetadataResponse>* writer);
         ::grpc::Status GetAttributeMetadata(::grpc::ServerContext* context, const taish::GetAttributeMetadataRequest* request, taish::GetAttributeMetadataResponse* response);
+        ::grpc::Status GetAttributeCapability(::grpc::ServerContext* context, const taish::GetAttributeCapabilityRequest* request, taish::GetAttributeCapabilityResponse* response);
         ::grpc::Status GetAttribute(::grpc::ServerContext* context, const taish::GetAttributeRequest* request, taish::GetAttributeResponse* response);
         ::grpc::Status SetAttribute(::grpc::ServerContext* context, const taish::SetAttributeRequest* request, taish::SetAttributeResponse* response);
         ::grpc::Status ClearAttribute(::grpc::ServerContext* context, const taish::ClearAttributeRequest* request, taish::ClearAttributeResponse* response);

--- a/tools/taish/proto/taish/taish.proto
+++ b/tools/taish/proto/taish/taish.proto
@@ -7,6 +7,7 @@ service TAI {
     rpc ListAttributeMetadata(ListAttributeMetadataRequest) returns (stream ListAttributeMetadataResponse);
     rpc GetAttributeMetadata(GetAttributeMetadataRequest) returns (GetAttributeMetadataResponse);
     rpc GetAttribute(GetAttributeRequest) returns (GetAttributeResponse);
+    rpc GetAttributeCapability(GetAttributeCapabilityRequest) returns (GetAttributeCapabilityResponse);
     rpc SetAttribute(SetAttributeRequest) returns (SetAttributeResponse);
     rpc ClearAttribute(ClearAttributeRequest) returns (ClearAttributeResponse);
     rpc Monitor(MonitorRequest) returns (stream MonitorResponse);
@@ -74,6 +75,16 @@ message GetAttributeMetadataRequest {
 
 message GetAttributeMetadataResponse {
     AttributeMetadata metadata = 1;
+}
+
+message GetAttributeCapabilityRequest {
+    uint64 oid = 1;
+    uint64 attr_id = 2;
+    SerializeOption serialize_option = 3;
+}
+
+message GetAttributeCapabilityResponse {
+    AttributeCapability capability = 1;
 }
 
 message GetAttributeRequest {
@@ -156,6 +167,14 @@ message AttributeMetadata {
     bool is_createandset = 9;
     bool is_key = 10;
     bool is_enum = 11;
+}
+
+message AttributeCapability {
+    uint64 attr_id = 1;
+    string default_value = 2;
+    string min = 3;
+    string max = 4;
+    repeated string supportedvalues = 5;
 }
 
 message HostInterface {


### PR DESCRIPTION
This PR adds capability APIs to TAI so that the TAI adapter host can retrieve the runtime capability of the hardware like supported enum values or minimum or maximum values of the attributes.
This adds get_capability APIs for each TAI object.

For example, as for TAI module, two new APIs `get_module_capability()` and `get_module_capabilities()`. are added.
`get_module_capability()` is used to get the capability of a single TAI attribute and `get_module_capabilities` is used to get the capability of multiple TAI attributes with one API call.

`tai_attribute_capability_t` is the struct that represents the capability of the TAI attribute. It can contain the runtime default value of the attribute, minimum and maximum value of the attribute, and supported enum values of the attribute.

```c
typedef struct _tai_attribute_capability_t {
    tai_attr_id_t         id;

    /* default value is set by TAI adapter */
    bool                  valid_defaultvalue;
    /* min is set by TAI adapter */
    bool                  valid_min;
    /* max is set by TAI adapter */
    bool                  valid_max;
    /* supportedvalues is set by TAI adapter */
    bool                  valid_supportedvalues;

    /* default value of this attribute */
    tai_attribute_value_t defaultvalue;

    /* minimum value of this attribute */
    tai_attribute_value_t min;

    /* maximum value of this attribute */
    tai_attribute_value_t max;

    /* supported values of this attribute ( only valid for enum attribute ) */
    tai_attr_value_list_t supportedvalues;

} tai_attribute_capability_t;
```

The difference between TAI metadata and TAI capability is if it is compile-time information or runtime information.
TAI metadata is compile-time information. It is generated by parsing the TAI headers when compiling a TAI library.
Whereas, TAI capability is runtime information. The TAI adapter host can know the exact runtime capability of the hardware via TAI capability APIs.

The TAI capability APIs avoids adding ad-hoc read-only TAI attributes for getting the capability of the TAI attribute.
For example, we have `TAI_NETWORK_INTERFACE_ATTR_MIN_LASER_FREQ` and `TAI_NETWORK_INTERFACE_ATTR_MAX_LASER_FREQ` to know the valid frequency of `TAI_NETWORK_INTERFACE_ATTR_TX_LASER_FREQ`.
We can use TAI capability API instead to get this information without adding new TAI attributes.

The hardware may not support all the enums of a TAI attribute. For example, there are 12 modulation formats defined in [tai_network_interface_modulation_format_t](https://github.com/Telecominfraproject/oopt-tai/blob/master/inc/tainetworkif.h#L84-L95). However, it is not likely that hardware supports all of these formats.
By using TAI capability, the TAI adapter host can know which enum values are actually supported by the hardware without doing trial-and-error with set_attribute API.

This PR also updates the TAI library framework and TAI shell to support the new TAI capability APIs.

`libtai-basic.so` ( under `framework/example/basic` ) shows how to support TAI capability APIs in TAI adapter when using the TAI library framework.