### PR TITLE
inc: add an attribute for implementation templates

### DIFF
--- a/inc/taimetadatatypes.h
+++ b/inc/taimetadatatypes.h
@@ -187,6 +187,10 @@ typedef enum _tai_attr_value_type_t
      */
     TAI_ATTR_VALUE_TYPE_NOTIFICATION,
 
+    /*
+     * @brief Attribute value is list of enums.
+     */
+    TAI_ATTR_VALUE_TYPE_ENUMLIST,
 } tai_attr_value_type_t;
 
 /**

--- a/inc/tainetworkif.h
+++ b/inc/tainetworkif.h
@@ -323,6 +323,27 @@ typedef enum _tai_network_interface_attr_t
     TAI_NETWORK_INTERFACE_ATTR_CLIENT_SIGNAL_MAPPING_TYPE,
 
     /**
+     * @brief The implementation templates
+     *
+     * Implementation templates represent the list of transmission modes
+     * supported by the network interface. Implementation templates are
+     * described as a list of enum lists, and each transmission mode is
+     * expressed as a combination of enum values. Each enum list has an enum id
+     * (attribute id) and a list of enum values. The i-th transmission mode is a
+     * combination of i-th values of each enum list.
+     *
+     * Implementation templates also represent the preference among the
+     * transmission modes. When only a part of the parameters corresponds to the
+     * transmission mode is configured, then the first mode that matches the
+     * current configured value will be used. Therefore the head of the list is
+     * the default mode.
+     *
+     * @type #tai_attr_value_list_t #tai_enum_list_t
+     * @flags READ_ONLY
+     */
+    TAI_NETWORK_INTERFACE_ATTR_IMPLEMENTATION_TEMPLATES,
+
+    /**
      * @brief The current pre-FEC bit error rate
      *
      * @type #tai_float_t

--- a/inc/taitypes.h
+++ b/inc/taitypes.h
@@ -250,6 +250,12 @@ typedef struct _tai_notification_handler_t {
     tai_notification_fn notify;
 } tai_notification_handler_t;
 
+typedef struct _tai_enum_list_t {
+    tai_attr_id_t id;
+    uint32_t count;
+    int32_t *list;
+} tai_enum_list_t;
+
 /**
  * @brief Data Type
  *
@@ -286,6 +292,7 @@ typedef union _tai_attribute_value_t
     tai_object_map_list_t objmaplist;
     tai_attr_value_list_t attrlist;
     tai_notification_handler_t notification;
+    tai_enum_list_t enumlist;
 } tai_attribute_value_t;
 
 typedef struct _tai_attribute_t


### PR DESCRIPTION
Implementation templates represent the list of transmission modes
supported by the network interface. Implementation templates are
described as a list of enum lists, and each transmission mode is
expressed as a combination of enum values. Each enum list has an enum
id (attribute id) and a list of enum values. The i-th transmission
mode is a combination of i-th values of each enum list.

Implementation templates also represent the preference among the
transmission modes. When only a part of the parameters corresponds to
the transmission mode is configured, then the first mode that matches
the current configured value will be used. Therefore the head of the
list is the default mode.